### PR TITLE
Enhance piano layout with fixed key range and dynamic width adjustments

### DIFF
--- a/lib/pages/play_page.dart
+++ b/lib/pages/play_page.dart
@@ -10,7 +10,6 @@ import "package:piano_fitness/models/midi_state.dart";
 import "package:piano_fitness/pages/midi_settings_page.dart";
 import "package:piano_fitness/pages/practice_page.dart";
 import "package:piano_fitness/services/midi_service.dart";
-import "package:piano_fitness/utils/piano_range_utils.dart";
 import "package:piano_fitness/widgets/practice_settings_panel.dart";
 import "package:provider/provider.dart";
 
@@ -384,15 +383,27 @@ class _PlayPageState extends State<PlayPage> {
           Expanded(
             child: Consumer<MidiState>(
               builder: (context, midiState, child) {
-                // Calculate optimal range based on highlighted notes
-                final optimalRange = PianoRangeUtils.calculateOptimalRange(
-                  midiState.highlightedNotePositions,
+                // Define a fixed 49-key range (C2 to C6) for consistent layout
+                final fixed49KeyRange = NoteRange(
+                  from: NotePosition(note: Note.C, octave: 2),
+                  to: NotePosition(note: Note.C, octave: 6),
                 );
+
+                // Calculate dynamic key width based on screen width
+                // 49 keys = 28 white keys + 21 black keys
+                // White keys take ~70% of the width, black keys are narrower
+                final screenWidth = MediaQuery.of(context).size.width;
+                final availableWidth = screenWidth - 32; // Account for padding
+                final dynamicKeyWidth =
+                    availableWidth / 29; // 28 white keys + buffer
 
                 return InteractivePiano(
                   highlightedNotes: midiState.highlightedNotePositions,
-                  keyWidth: 45,
-                  noteRange: optimalRange,
+                  keyWidth: dynamicKeyWidth.clamp(
+                    20.0,
+                    60.0,
+                  ), // Reasonable limits
+                  noteRange: fixed49KeyRange,
                   onNotePositionTapped: (position) {
                     final midiNote = _convertNotePositionToMidi(position);
                     _playVirtualNote(midiNote);

--- a/lib/pages/play_page.dart
+++ b/lib/pages/play_page.dart
@@ -276,6 +276,7 @@ class _PlayPageState extends State<PlayPage> {
       body: Column(
         children: [
           Expanded(
+            flex: 4,
             child: SafeArea(
               bottom: false,
               child: SingleChildScrollView(

--- a/lib/pages/play_page.dart
+++ b/lib/pages/play_page.dart
@@ -10,6 +10,7 @@ import "package:piano_fitness/models/midi_state.dart";
 import "package:piano_fitness/pages/midi_settings_page.dart";
 import "package:piano_fitness/pages/practice_page.dart";
 import "package:piano_fitness/services/midi_service.dart";
+import "package:piano_fitness/utils/piano_range_utils.dart";
 import "package:piano_fitness/widgets/practice_settings_panel.dart";
 import "package:provider/provider.dart";
 
@@ -390,19 +391,18 @@ class _PlayPageState extends State<PlayPage> {
                 );
 
                 // Calculate dynamic key width based on screen width
-                // 49 keys = 28 white keys + 21 black keys
-                // White keys take ~70% of the width, black keys are narrower
                 final screenWidth = MediaQuery.of(context).size.width;
-                final availableWidth = screenWidth - 32; // Account for padding
                 final dynamicKeyWidth =
-                    availableWidth / 29; // 28 white keys + buffer
+                    PianoRangeUtils.calculateScreenBasedKeyWidth(
+                      screenWidth,
+                    );
 
                 return InteractivePiano(
                   highlightedNotes: midiState.highlightedNotePositions,
                   keyWidth: dynamicKeyWidth.clamp(
-                    20.0,
-                    60.0,
-                  ), // Reasonable limits
+                    PianoRangeUtils.minKeyWidth,
+                    PianoRangeUtils.maxKeyWidth,
+                  ),
                   noteRange: fixed49KeyRange,
                   onNotePositionTapped: (position) {
                     final midiNote = _convertNotePositionToMidi(position);

--- a/lib/utils/note_utils.dart
+++ b/lib/utils/note_utils.dart
@@ -265,6 +265,26 @@ class NoteUtils {
     return midiNumber;
   }
 
+  /// Converts a MIDI note number to a NotePosition for the piano widget.
+  ///
+  /// This method provides a direct conversion from MIDI numbers to NotePosition
+  /// objects that can be used with the InteractivePiano widget. It combines
+  /// [midiNumberToNote] and [noteToNotePosition] into a single operation.
+  ///
+  /// The [midiNumber] must be in the valid MIDI range (0-127).
+  /// Returns null if the MIDI number is outside the valid range.
+  ///
+  /// Example: `midiNumberToNotePosition(60)` returns NotePosition for middle C.
+  static NotePosition? midiNumberToNotePosition(int midiNumber) {
+    // Pre-validate MIDI number to avoid exceptions
+    if (midiNumber < 0 || midiNumber > 127) {
+      return null;
+    }
+
+    final noteInfo = midiNumberToNote(midiNumber);
+    return noteToNotePosition(noteInfo.note, noteInfo.octave);
+  }
+
   /// Generates a human-readable display name for a musical note.
   ///
   /// The [note] and [octave] parameters specify which note to format.

--- a/lib/utils/piano_range_utils.dart
+++ b/lib/utils/piano_range_utils.dart
@@ -22,6 +22,16 @@ class PianoRangeUtils {
   /// Upper bound of standard 88-key piano range (C8).
   static const int max88KeyMidi = 108; // C8
 
+  /// Octave conversion constants
+
+  /// Number of semitones in one octave.
+  static const int semitonesPerOctave = 12;
+
+  /// Number of semitones in two octaves.
+  static const int twoOctavesSemitones = 24; // 2 * semitonesPerOctave
+  /// Number of semitones in four octaves.
+  static const int fourOctavesSemitones = 48; // 4 * semitonesPerOctave
+
   /// Buffer notes to add on each side of the highlighted range
   static const int bufferSemitones = semitonesPerOctave; // One octave buffer
 
@@ -50,19 +60,10 @@ class PianoRangeUtils {
   /// Total number of keys in the fixed practice range (4 octaves + 1 note).
   static const int fixed49KeyCount = 49; // 4 octaves + 1 note
   /// Number of semitones in the 49-key range (4 octaves).
-  static const int fixed49KeySemitones = 48; // 4 octaves in semitones
+  static const int fixed49KeySemitones =
+      fourOctavesSemitones; // 4 octaves in semitones
   /// Half-width of the 49-key range in semitones (2 octaves on each side of center).
   static const int fixed49KeyHalfWidth = 24; // 2 octaves on each side
-
-  /// Octave conversion constants
-
-  /// Number of semitones in one octave.
-  static const int semitonesPerOctave = 12;
-
-  /// Number of semitones in two octaves.
-  static const int twoOctavesSemitones = 24; // 2 * semitonesPerOctave
-  /// Number of semitones in four octaves.
-  static const int fourOctavesSemitones = 48; // 4 * semitonesPerOctave
 
   /// Calculates an optimal note range that centers around the given highlighted notes.
   ///

--- a/lib/utils/piano_range_utils.dart
+++ b/lib/utils/piano_range_utils.dart
@@ -82,7 +82,9 @@ class PianoRangeUtils {
     }
 
     // Convert note positions to MIDI numbers for easier calculation
-    final midiNotes = highlightedNotes.map(NoteUtils.convertNotePositionToMidi).toList();
+    final midiNotes = highlightedNotes
+        .map(NoteUtils.convertNotePositionToMidi)
+        .toList();
 
     if (midiNotes.isEmpty) {
       return fallbackRange ?? defaultRange;
@@ -118,8 +120,8 @@ class PianoRangeUtils {
     endMidi = endMidi.clamp(min88KeyMidi, max88KeyMidi);
 
     // Convert back to note positions using NoteUtils
-    final startPosition = _midiToNotePosition(startMidi);
-    final endPosition = _midiToNotePosition(endMidi);
+    final startPosition = NoteUtils.midiNumberToNotePosition(startMidi);
+    final endPosition = NoteUtils.midiNumberToNotePosition(endMidi);
 
     if (startPosition == null || endPosition == null) {
       return fallbackRange ?? defaultRange;
@@ -144,7 +146,7 @@ class PianoRangeUtils {
 
     // Convert MIDI numbers to note positions
     final notePositions = midiSequence
-        .map(_midiToNotePosition)
+        .map(NoteUtils.midiNumberToNotePosition)
         .where((pos) => pos != null)
         .cast<NotePosition>()
         .toList();
@@ -259,27 +261,14 @@ class PianoRangeUtils {
     endMidi = endMidi.clamp(min88KeyMidi, max88KeyMidi);
 
     // Convert back to note positions using NoteUtils
-    final startPosition = _midiToNotePosition(startMidi);
-    final endPosition = _midiToNotePosition(endMidi);
+    final startPosition = NoteUtils.midiNumberToNotePosition(startMidi);
+    final endPosition = NoteUtils.midiNumberToNotePosition(endMidi);
 
     if (startPosition == null || endPosition == null) {
       return fallbackRange ?? defaultRange;
     }
 
     return NoteRange(from: startPosition, to: endPosition);
-  }
-
-  /// Helper method to convert MIDI number to NotePosition using NoteUtils.
-  /// 
-  /// Returns null if the MIDI number is invalid.
-  static NotePosition? _midiToNotePosition(int midiNote) {
-    // Pre-validate MIDI number to avoid exceptions
-    if (midiNote < 0 || midiNote > 127) {
-      return null;
-    }
-    
-    final noteInfo = NoteUtils.midiNumberToNote(midiNote);
-    return NoteUtils.noteToNotePosition(noteInfo.note, noteInfo.octave);
   }
 
   /// Calculates a fixed 49-key range centered around practice exercise notes.
@@ -361,8 +350,8 @@ class PianoRangeUtils {
     }
 
     // Convert MIDI notes to NotePosition using NoteUtils
-    final startPosition = _midiToNotePosition(startNote);
-    final endPosition = _midiToNotePosition(endNote);
+    final startPosition = NoteUtils.midiNumberToNotePosition(startNote);
+    final endPosition = NoteUtils.midiNumberToNotePosition(endNote);
 
     if (startPosition == null || endPosition == null) {
       return defaultFallback;

--- a/lib/utils/piano_range_utils.dart
+++ b/lib/utils/piano_range_utils.dart
@@ -32,6 +32,12 @@ class PianoRangeUtils {
   /// Key width for very wide ranges (28 pixels).
   static const double veryNarrowKeyWidth = 28;
 
+  /// Minimum allowed key width for screen-based calculations (20 pixels).
+  static const double minKeyWidth = 20;
+
+  /// Maximum allowed key width for screen-based calculations (60 pixels).
+  static const double maxKeyWidth = 60;
+
   /// Thresholds for automatic key width adjustment (in semitones)
   static const int narrowKeyThreshold = 48; // 4 octaves
   /// Range size threshold for very narrow keys (5 octaves in semitones).
@@ -344,7 +350,8 @@ class PianoRangeUtils {
     NoteRange? fallbackRange,
   }) {
     // Default 49-key range (C2 to C6) when no exercise is active
-    final defaultFallback = fallbackRange ??
+    final defaultFallback =
+        fallbackRange ??
         NoteRange(
           from: NotePosition(note: Note.C, octave: 2),
           to: NotePosition(note: Note.C, octave: 6),
@@ -402,16 +409,16 @@ class PianoRangeUtils {
   /// [screenWidth] - Available screen width in pixels
   /// [padding] - Total horizontal padding to account for (default: 32)
   /// [keyCount] - Number of white keys to fit (default: 28 for 49-key range)
-  /// [minWidth] - Minimum key width in pixels (default: 20)
-  /// [maxWidth] - Maximum key width in pixels (default: 60)
+  /// [minWidth] - Minimum key width in pixels (default: minKeyWidth = 20)
+  /// [maxWidth] - Maximum key width in pixels (default: maxKeyWidth = 60)
   ///
   /// Returns the optimal key width in pixels.
   static double calculateScreenBasedKeyWidth(
     double screenWidth, {
     double padding = 32.0,
     int keyCount = 28, // 28 white keys in 49-key range
-    double minWidth = 20.0,
-    double maxWidth = 60.0,
+    double minWidth = minKeyWidth,
+    double maxWidth = maxKeyWidth,
   }) {
     final availableWidth = screenWidth - padding;
     final calculatedWidth = availableWidth / (keyCount + 1); // +1 for buffer

--- a/test/utils/note_utils_test.dart
+++ b/test/utils/note_utils_test.dart
@@ -141,6 +141,133 @@ void main() {
       });
     });
 
+    group("midiNumberToNotePosition", () {
+      test("should convert basic MIDI numbers to NotePosition", () {
+        // Test middle C
+        final c4 = NoteUtils.midiNumberToNotePosition(60);
+        expect(c4?.note, equals(Note.C));
+        expect(c4?.octave, equals(4));
+        expect(c4?.accidental, equals(Accidental.None));
+
+        // Test A4
+        final a4 = NoteUtils.midiNumberToNotePosition(69);
+        expect(a4?.note, equals(Note.A));
+        expect(a4?.octave, equals(4));
+        expect(a4?.accidental, equals(Accidental.None));
+      });
+
+      test("should convert sharp notes correctly", () {
+        // Test C#4
+        final cSharp4 = NoteUtils.midiNumberToNotePosition(61);
+        expect(cSharp4?.note, equals(Note.C));
+        expect(cSharp4?.octave, equals(4));
+        expect(cSharp4?.accidental, equals(Accidental.Sharp));
+
+        // Test F#4
+        final fSharp4 = NoteUtils.midiNumberToNotePosition(66);
+        expect(fSharp4?.note, equals(Note.F));
+        expect(fSharp4?.octave, equals(4));
+        expect(fSharp4?.accidental, equals(Accidental.Sharp));
+
+        // Test A#4
+        final aSharp4 = NoteUtils.midiNumberToNotePosition(70);
+        expect(aSharp4?.note, equals(Note.A));
+        expect(aSharp4?.octave, equals(4));
+        expect(aSharp4?.accidental, equals(Accidental.Sharp));
+      });
+
+      test("should handle different octaves", () {
+        // Test C in different octaves
+        final c0 = NoteUtils.midiNumberToNotePosition(12);
+        expect(c0?.note, equals(Note.C));
+        expect(c0?.octave, equals(0));
+
+        final c1 = NoteUtils.midiNumberToNotePosition(24);
+        expect(c1?.note, equals(Note.C));
+        expect(c1?.octave, equals(1));
+
+        final c2 = NoteUtils.midiNumberToNotePosition(36);
+        expect(c2?.note, equals(Note.C));
+        expect(c2?.octave, equals(2));
+
+        final c6 = NoteUtils.midiNumberToNotePosition(84);
+        expect(c6?.note, equals(Note.C));
+        expect(c6?.octave, equals(6));
+      });
+
+      test("should handle extreme MIDI ranges", () {
+        // Test lowest MIDI note (C-1)
+        final lowestC = NoteUtils.midiNumberToNotePosition(0);
+        expect(lowestC?.note, equals(Note.C));
+        expect(lowestC?.octave, equals(-1));
+
+        // Test highest MIDI note (G9)
+        final highestG = NoteUtils.midiNumberToNotePosition(127);
+        expect(highestG?.note, equals(Note.G));
+        expect(highestG?.octave, equals(9));
+
+        // Test 88-key piano range boundaries
+        final a0 = NoteUtils.midiNumberToNotePosition(
+          21,
+        ); // A0 - lowest piano key
+        expect(a0?.note, equals(Note.A));
+        expect(a0?.octave, equals(0));
+
+        final c8 = NoteUtils.midiNumberToNotePosition(
+          108,
+        ); // C8 - highest piano key
+        expect(c8?.note, equals(Note.C));
+        expect(c8?.octave, equals(8));
+      });
+
+      test("should return null for invalid MIDI numbers", () {
+        expect(NoteUtils.midiNumberToNotePosition(-1), isNull);
+        expect(NoteUtils.midiNumberToNotePosition(128), isNull);
+        expect(NoteUtils.midiNumberToNotePosition(200), isNull);
+        expect(NoteUtils.midiNumberToNotePosition(-100), isNull);
+      });
+
+      test("should handle all chromatic notes in an octave", () {
+        // Test all 12 semitones in octave 4
+        final expectedNotes = [
+          (Note.C, Accidental.None), // MIDI 60
+          (Note.C, Accidental.Sharp), // MIDI 61
+          (Note.D, Accidental.None), // MIDI 62
+          (Note.D, Accidental.Sharp), // MIDI 63
+          (Note.E, Accidental.None), // MIDI 64
+          (Note.F, Accidental.None), // MIDI 65
+          (Note.F, Accidental.Sharp), // MIDI 66
+          (Note.G, Accidental.None), // MIDI 67
+          (Note.G, Accidental.Sharp), // MIDI 68
+          (Note.A, Accidental.None), // MIDI 69
+          (Note.A, Accidental.Sharp), // MIDI 70
+          (Note.B, Accidental.None), // MIDI 71
+        ];
+
+        for (var i = 0; i < 12; i++) {
+          final midiNumber = 60 + i; // C4 to B4
+          final notePos = NoteUtils.midiNumberToNotePosition(midiNumber);
+          final expected = expectedNotes[i];
+
+          expect(
+            notePos?.note,
+            equals(expected.$1),
+            reason: "MIDI $midiNumber should be ${expected.$1}",
+          );
+          expect(
+            notePos?.accidental,
+            equals(expected.$2),
+            reason: "MIDI $midiNumber should have accidental ${expected.$2}",
+          );
+          expect(
+            notePos?.octave,
+            equals(4),
+            reason: "MIDI $midiNumber should be in octave 4",
+          );
+        }
+      });
+    });
+
     group("noteDisplayName", () {
       test("should format note names correctly", () {
         expect(NoteUtils.noteDisplayName(MusicalNote.c, 4), equals("C4"));
@@ -175,6 +302,108 @@ void main() {
               expect(noteInfo.note, equals(note));
               expect(noteInfo.octave, equals(octave));
             }
+          }
+        }
+      });
+
+      test("MIDI to NotePosition and back should be consistent", () {
+        for (var midi = 0; midi <= 127; midi++) {
+          final notePos = NoteUtils.midiNumberToNotePosition(midi);
+          expect(
+            notePos,
+            isNotNull,
+            reason: "MIDI $midi should convert to valid NotePosition",
+          );
+
+          if (notePos != null) {
+            final convertedBack = NoteUtils.convertNotePositionToMidi(notePos);
+            expect(
+              convertedBack,
+              equals(midi),
+              reason:
+                  "MIDI $midi -> NotePosition -> $convertedBack should be consistent",
+            );
+          }
+        }
+      });
+
+      test("NotePosition to MIDI to NotePosition should be consistent", () {
+        final testCases = [
+          NotePosition(note: Note.C),
+          NotePosition(note: Note.C, accidental: Accidental.Sharp),
+          NotePosition(note: Note.D),
+          NotePosition(note: Note.D, accidental: Accidental.Sharp),
+          NotePosition(note: Note.E),
+          NotePosition(note: Note.F),
+          NotePosition(note: Note.F, accidental: Accidental.Sharp),
+          NotePosition(note: Note.G),
+          NotePosition(note: Note.G, accidental: Accidental.Sharp),
+          NotePosition(note: Note.A),
+          NotePosition(note: Note.A, accidental: Accidental.Sharp),
+          NotePosition(note: Note.B),
+          // Test different octaves
+          NotePosition(note: Note.C, octave: 0),
+          NotePosition(note: Note.C, octave: 8),
+          NotePosition(note: Note.A, octave: 0),
+        ];
+
+        // Special test cases for flat notes (which convert to sharp equivalents)
+        final flatToSharpEquivalents = [
+          (
+            NotePosition(note: Note.D, accidental: Accidental.Flat),
+            NotePosition(note: Note.C, accidental: Accidental.Sharp),
+          ),
+          (
+            NotePosition(note: Note.B, accidental: Accidental.Flat),
+            NotePosition(note: Note.A, accidental: Accidental.Sharp),
+          ),
+        ];
+
+        // Test normal cases where the conversion should be identical
+        for (final originalPos in testCases) {
+          final midi = NoteUtils.convertNotePositionToMidi(originalPos);
+          final convertedPos = NoteUtils.midiNumberToNotePosition(midi);
+
+          expect(
+            convertedPos,
+            isNotNull,
+            reason:
+                "NotePosition ${originalPos.note}${originalPos.octave} should convert to valid MIDI and back",
+          );
+
+          if (convertedPos != null) {
+            expect(convertedPos.note, equals(originalPos.note));
+            expect(convertedPos.octave, equals(originalPos.octave));
+            expect(convertedPos.accidental, equals(originalPos.accidental));
+          }
+        }
+
+        // Test flat note equivalents (they should convert to their sharp equivalents)
+        for (final (flatNote, expectedSharpNote) in flatToSharpEquivalents) {
+          final midi = NoteUtils.convertNotePositionToMidi(flatNote);
+          final convertedPos = NoteUtils.midiNumberToNotePosition(midi);
+
+          expect(
+            convertedPos,
+            isNotNull,
+            reason:
+                "Flat note ${flatNote.note}${flatNote.octave} should convert to valid MIDI and back",
+          );
+
+          if (convertedPos != null) {
+            expect(
+              convertedPos.note,
+              equals(expectedSharpNote.note),
+              reason:
+                  "${flatNote.note}♭ should convert to ${expectedSharpNote.note}♯",
+            );
+            expect(convertedPos.octave, equals(expectedSharpNote.octave));
+            expect(
+              convertedPos.accidental,
+              equals(expectedSharpNote.accidental),
+              reason:
+                  "${flatNote.note}♭ should convert to ${expectedSharpNote.note}♯",
+            );
           }
         }
       });

--- a/test/utils/note_utils_test.dart
+++ b/test/utils/note_utils_test.dart
@@ -145,12 +145,14 @@ void main() {
       test("should convert basic MIDI numbers to NotePosition", () {
         // Test middle C
         final c4 = NoteUtils.midiNumberToNotePosition(60);
+        expect(c4, isNotNull);
         expect(c4?.note, equals(Note.C));
         expect(c4?.octave, equals(4));
         expect(c4?.accidental, equals(Accidental.None));
 
         // Test A4
         final a4 = NoteUtils.midiNumberToNotePosition(69);
+        expect(a4, isNotNull);
         expect(a4?.note, equals(Note.A));
         expect(a4?.octave, equals(4));
         expect(a4?.accidental, equals(Accidental.None));


### PR DESCRIPTION
Introduce a fixed 49-key range for the piano layout, ensuring consistent display across practice exercises. Implement dynamic key width calculations based on screen size for improved usability. Update architecture documentation to reflect modular structure and file organization. Add tests for the new key range and width functionalities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The piano keyboard now consistently displays a fixed 49-key range, centered around exercise notes in practice mode and set from C2 to C6 in play mode.
  * Piano key widths are dynamically calculated based on screen size for improved responsiveness.

* **Documentation**
  * Expanded and reorganized architecture and testing documentation with detailed guides on app structure, piano layout, and testing strategies.

* **Tests**
  * Added comprehensive tests for fixed 49-key range calculations and dynamic key width sizing.
  * Added tests for MIDI-to-NotePosition conversion and bidirectional consistency between MIDI numbers and note positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->