### PR TITLE
Enhance practice mode tests and snackbar functionality

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,6 +25,7 @@ linter:
     prefer_single_quotes: false # Disable single quote preference - use double quotes
     prefer_double_quotes: true # Use double quotes for strings
     unnecessary_breaks: false # Disable unnecessary breaks warning for switch statements
+    cascade_invocations: false # Disable cascade invocations rule - cascades are idiomatic Dart
     # Code quality rules to enforce best practices
     avoid_function_literals_in_foreach_calls: true
     avoid_redundant_argument_values: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,7 +7,7 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
-include: package:very_good_analysis/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 linter:
   # The lint rules applied to this project can be customized in the
@@ -25,7 +25,7 @@ linter:
     prefer_single_quotes: false # Disable single quote preference - use double quotes
     prefer_double_quotes: true # Use double quotes for strings
     unnecessary_breaks: false # Disable unnecessary breaks warning for switch statements
-    cascade_invocations: false # Disable cascade invocations rule - cascades are idiomatic Dart
+    cascade_invocations: true # Allow cascade notation for method calls
     # Code quality rules to enforce best practices
     avoid_function_literals_in_foreach_calls: true
     avoid_redundant_argument_values: true

--- a/lib/shared/models/practice_session.dart
+++ b/lib/shared/models/practice_session.dart
@@ -317,4 +317,14 @@ class PracticeSession {
     _currentlyHeldChordNotes.clear();
     _updateHighlightedNotes();
   }
+
+  /// Triggers exercise completion for testing purposes only.
+  ///
+  /// This method is intended for use in unit tests to simulate
+  /// the completion of a practice exercise without having to
+  /// play through the entire sequence.
+  @visibleForTesting
+  void triggerCompletionForTesting() {
+    _completeExercise();
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,6 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^9.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/features/practice/practice_page_test.dart
+++ b/test/features/practice/practice_page_test.dart
@@ -147,17 +147,14 @@ void main() {
       // The highlighted notes should be managed by the ViewModel
       expect(piano.highlightedNotes, isNotNull);
 
-      // Use runAsync to properly handle the timer from _triggerActivity
-      await tester.runAsync(() async {
-        // Add a note to verify the connection works
-        midiState.noteOn(60, 100, 1);
-        await tester.pump();
+      // Add a note to verify the connection works
+      midiState.noteOn(60, 100, 1);
+      await tester.pump();
 
-        expect(midiState.highlightedNotePositions.isNotEmpty, isTrue);
+      expect(midiState.highlightedNotePositions.isNotEmpty, isTrue);
 
-        // Wait for the activity timer to complete or let it be handled by runAsync
-        await Future<void>.delayed(const Duration(milliseconds: 1100));
-      });
+      // Simulate the activity timer elapsing deterministically
+      await tester.pump(const Duration(milliseconds: 1100));
 
       // Properly dispose to clean up any remaining timers
       midiState.dispose();

--- a/test/features/practice/practice_page_test.dart
+++ b/test/features/practice/practice_page_test.dart
@@ -245,6 +245,24 @@ void main() {
           find.byKey(const Key("practice_settings_panel")),
           findsOneWidget,
         );
+
+        // Assert that the practice mode dropdown shows scales mode
+        final practiceModeDropdown = find.byType(
+          DropdownButtonFormField<PracticeMode>,
+        );
+        expect(practiceModeDropdown, findsOneWidget);
+
+        // Access the DropdownButton inside the FormField to check its value
+        final dropdownButton = find.descendant(
+          of: practiceModeDropdown,
+          matching: find.byType(DropdownButton<PracticeMode>),
+        );
+        expect(dropdownButton, findsOneWidget);
+
+        final button = tester.widget<DropdownButton<PracticeMode>>(
+          dropdownButton,
+        );
+        expect(button.value, PracticeMode.scales);
       });
 
       testWidgets("should initialize with chords mode when specified", (
@@ -265,6 +283,24 @@ void main() {
           find.byKey(const Key("practice_settings_panel")),
           findsOneWidget,
         );
+
+        // Assert that the practice mode dropdown shows chords mode
+        final practiceModeDropdown = find.byType(
+          DropdownButtonFormField<PracticeMode>,
+        );
+        expect(practiceModeDropdown, findsOneWidget);
+
+        // Access the DropdownButton inside the FormField to check its value
+        final dropdownButton = find.descendant(
+          of: practiceModeDropdown,
+          matching: find.byType(DropdownButton<PracticeMode>),
+        );
+        expect(dropdownButton, findsOneWidget);
+
+        final button = tester.widget<DropdownButton<PracticeMode>>(
+          dropdownButton,
+        );
+        expect(button.value, PracticeMode.chords);
       });
 
       testWidgets("should initialize with arpeggios mode when specified", (
@@ -285,6 +321,24 @@ void main() {
           find.byKey(const Key("practice_settings_panel")),
           findsOneWidget,
         );
+
+        // Assert that the practice mode dropdown shows arpeggios mode
+        final practiceModeDropdown = find.byType(
+          DropdownButtonFormField<PracticeMode>,
+        );
+        expect(practiceModeDropdown, findsOneWidget);
+
+        // Access the DropdownButton inside the FormField to check its value
+        final dropdownButton = find.descendant(
+          of: practiceModeDropdown,
+          matching: find.byType(DropdownButton<PracticeMode>),
+        );
+        expect(dropdownButton, findsOneWidget);
+
+        final button = tester.widget<DropdownButton<PracticeMode>>(
+          dropdownButton,
+        );
+        expect(button.value, PracticeMode.arpeggios);
       });
     });
 

--- a/test/features/practice/practice_page_test.dart
+++ b/test/features/practice/practice_page_test.dart
@@ -215,7 +215,7 @@ void main() {
       expect(find.byType(PracticePage), findsNothing);
     });
 
-    testWidgets("should show exercise completion snackbar", (tester) async {      
+    testWidgets("should show exercise completion snackbar", (tester) async {
       final testWidget = ChangeNotifierProvider(
         create: (context) => MidiState(),
         child: MaterialApp(
@@ -232,14 +232,14 @@ void main() {
 
       // Verify the practice page is loaded
       expect(find.byType(PracticePage), findsOneWidget);
-      
+
       // Find and tap the Start button to begin practice
       final startButton = find.text("Start");
       expect(startButton, findsOneWidget);
-      
+
       await tester.tap(startButton);
       await tester.pump();
-      
+
       // Find the practice session through the MidiState callback mechanism
       // This is a bit of a hack, but we'll create a practice session directly
       // and trigger its completion for testing
@@ -258,15 +258,15 @@ void main() {
         },
         onHighlightedNotesChanged: (notes) {},
       );
-      
+
       // Start the practice session and trigger completion
       testPracticeSession
         ..startPractice()
         ..triggerCompletionForTesting();
-      
+
       // Allow UI to update and show the snackbar
       await tester.pumpAndSettle();
-      
+
       // Verify the snackbar is displayed
       expect(find.byType(SnackBar), findsOneWidget);
       expect(find.text("Exercise completed! Well done!"), findsOneWidget);

--- a/test/features/practice/practice_page_test.dart
+++ b/test/features/practice/practice_page_test.dart
@@ -193,9 +193,10 @@ void main() {
 
         await tester.pumpWidget(testWidget);
 
-        // Before the post-frame callback, there might be a loading state
-        // This test verifies the UI handles uninitialized state gracefully
+        // Before the post-frame callback, there should be a loading indicator
+        // when the practice session is not yet initialized
         expect(find.byType(PracticePage), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
       },
     );
 


### PR DESCRIPTION
Improve testing for practice mode dropdown options (scales, chords, arpeggios) and add unit tests for exercise completion snackbar display and loading indicators in the practice session. Refactor MIDI note handling for better timer management. Disable cascade invocations rule in analysis options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved and expanded tests for the practice page, including more precise UI and state verification, better handling of asynchronous behavior, and enhanced assertions for dropdown initialization and snackbar display.

* **Chores**
  * Updated lint configuration to use flutter_lints and enabled cascade invocation lint rule.
  * Added a method to facilitate testing of practice session completion.
  * Removed an unused development dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->