### PR TITLE
Add display name extensions for musical keys

### DIFF
--- a/lib/features/device_controller/device_controller_page.dart
+++ b/lib/features/device_controller/device_controller_page.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_midi_command/flutter_midi_command.dart";
 import "package:piano_fitness/features/device_controller/device_controller_view_model.dart";
+import "package:piano_fitness/shared/utils/note_utils.dart";
 import "package:provider/provider.dart";
 
 /// A detailed controller interface for a specific MIDI device.
@@ -302,21 +303,8 @@ class _DeviceControllerPageState extends State<DeviceControllerPage> {
     Color color,
     DeviceControllerViewModel viewModel,
   ) {
-    final noteNames = [
-      "C",
-      "C#",
-      "D",
-      "D#",
-      "E",
-      "F",
-      "F#",
-      "G",
-      "G#",
-      "A",
-      "A#",
-      "B",
-    ];
-    final noteName = noteNames[midiNote % 12];
+    // Use centralized compact note naming to ensure consistency across the app
+    final noteName = NoteUtils.getCompactNoteName(midiNote);
 
     return GestureDetector(
       onTap: () => viewModel.sendNoteOn(midiNote),

--- a/lib/features/device_controller/device_controller_page.dart
+++ b/lib/features/device_controller/device_controller_page.dart
@@ -109,10 +109,7 @@ class _DeviceControllerPageState extends State<DeviceControllerPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              "MIDI Channel",
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
+            Text("MIDI Channel", style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 8),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -240,10 +237,7 @@ class _DeviceControllerPageState extends State<DeviceControllerPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              "Pitch Bend",
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
+            Text("Pitch Bend", style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 16),
             Slider(
               value: viewModel.pitchBend,

--- a/lib/features/midi_settings/midi_settings_page.dart
+++ b/lib/features/midi_settings/midi_settings_page.dart
@@ -25,9 +25,8 @@ class _MidiSettingsPageState extends State<MidiSettingsPage> {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (context) => MidiSettingsViewModel(
-        initialChannel: widget.initialChannel,
-      ),
+      create: (context) =>
+          MidiSettingsViewModel(initialChannel: widget.initialChannel),
       child: Consumer<MidiSettingsViewModel>(
         builder: (context, viewModel, child) {
           // Set up MIDI data handling with MidiState
@@ -113,10 +112,7 @@ class _MidiSettingsPageState extends State<MidiSettingsPage> {
         children: [
           const Text(
             "MIDI Output Channel",
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.bold,
-            ),
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 8),
           Row(
@@ -302,26 +298,16 @@ class _MidiSettingsPageState extends State<MidiSettingsPage> {
           ),
           child: Column(
             children: [
-              const Icon(
-                Icons.music_note,
-                color: Colors.green,
-                size: 32,
-              ),
+              const Icon(Icons.music_note, color: Colors.green, size: 32),
               const SizedBox(height: 8),
               const Text(
                 "MIDI Activity:",
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.bold,
-                ),
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 4),
               Text(
                 viewModel.lastNote,
-                style: const TextStyle(
-                  color: Colors.green,
-                  fontSize: 16,
-                ),
+                style: const TextStyle(color: Colors.green, fontSize: 16),
                 textAlign: TextAlign.center,
               ),
             ],
@@ -343,9 +329,8 @@ class _MidiSettingsPageState extends State<MidiSettingsPage> {
                 ? () => viewModel.retrySetup()
                 : () => viewModel.scanForDevices(
                     context,
-                    () => viewModel.informUserAboutBluetoothPermissions(
-                      context,
-                    ),
+                    () =>
+                        viewModel.informUserAboutBluetoothPermissions(context),
                     _showSnackBar,
                   )),
       tooltip: viewModel.isScanning
@@ -355,10 +340,7 @@ class _MidiSettingsPageState extends State<MidiSettingsPage> {
                 : "Scan for MIDI devices"),
       backgroundColor: viewModel.isScanning ? Colors.grey : null,
       child: viewModel.isScanning
-          ? const CircularProgressIndicator(
-              color: Colors.white,
-              strokeWidth: 2,
-            )
+          ? const CircularProgressIndicator(color: Colors.white, strokeWidth: 2)
           : Icon(
               viewModel.shouldShowErrorButtons
                   ? Icons.refresh
@@ -388,10 +370,7 @@ class _MidiSettingsPageState extends State<MidiSettingsPage> {
   void _showSnackBar(String message, [Color? backgroundColor]) {
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(message),
-          backgroundColor: backgroundColor,
-        ),
+        SnackBar(content: Text(message), backgroundColor: backgroundColor),
       );
     }
   }

--- a/lib/features/midi_settings/midi_settings_view_model.dart
+++ b/lib/features/midi_settings/midi_settings_view_model.dart
@@ -76,9 +76,7 @@ class MidiSettingsViewModel extends ChangeNotifier {
   }
 
   /// Shows Bluetooth permissions dialog.
-  Future<void> informUserAboutBluetoothPermissions(
-    BuildContext context,
-  ) async {
+  Future<void> informUserAboutBluetoothPermissions(BuildContext context) async {
     if (_didAskForBluetoothPermissions) {
       return;
     }
@@ -260,10 +258,7 @@ class MidiSettingsViewModel extends ChangeNotifier {
           throw Exception(err);
         });
 
-        showSnackBar(
-          "Scanning for Bluetooth MIDI devices...",
-          Colors.blue,
-        );
+        showSnackBar("Scanning for Bluetooth MIDI devices...", Colors.blue);
 
         await Future<void>.delayed(const Duration(seconds: 3));
         await updateDeviceList();
@@ -360,10 +355,7 @@ class MidiSettingsViewModel extends ChangeNotifier {
           print("Connecting to ${device.name}");
         }
         await _midiCommand.connectToDevice(device);
-        showSnackBar(
-          "Connected to ${device.name}",
-          Colors.green,
-        );
+        showSnackBar("Connected to ${device.name}", Colors.green);
       }
       await updateDeviceList();
     } on Exception catch (e) {
@@ -389,10 +381,7 @@ class MidiSettingsViewModel extends ChangeNotifier {
         orElse: () => currentDevice,
       );
       if (!updatedDevice.connected) {
-        showSnackBar(
-          "Failed to connect to device",
-          Colors.red,
-        );
+        showSnackBar("Failed to connect to device", Colors.red);
         return null;
       }
       currentDevice = updatedDevice;

--- a/lib/features/play/play_page.dart
+++ b/lib/features/play/play_page.dart
@@ -227,9 +227,7 @@ class _PlayPageState extends State<PlayPage> {
                 // Calculate dynamic key width based on screen width
                 final screenWidth = MediaQuery.of(context).size.width;
                 final dynamicKeyWidth =
-                    PianoRangeUtils.calculateScreenBasedKeyWidth(
-                      screenWidth,
-                    );
+                    PianoRangeUtils.calculateScreenBasedKeyWidth(screenWidth);
 
                 return InteractivePiano(
                   highlightedNotes: midiState.highlightedNotePositions,

--- a/lib/features/play/play_page.dart
+++ b/lib/features/play/play_page.dart
@@ -4,9 +4,9 @@ import "package:piano_fitness/features/midi_settings/midi_settings_page.dart";
 import "package:piano_fitness/features/play/play_page_view_model.dart";
 import "package:piano_fitness/features/practice/practice_page.dart";
 import "package:piano_fitness/shared/models/midi_state.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:piano_fitness/shared/utils/note_utils.dart";
 import "package:piano_fitness/shared/utils/piano_range_utils.dart";
-import "package:piano_fitness/shared/widgets/practice_settings_panel.dart";
 import "package:provider/provider.dart";
 
 /// The main page of the Piano Fitness application.

--- a/lib/features/practice/practice_page.dart
+++ b/lib/features/practice/practice_page.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:piano/piano.dart";
 import "package:piano_fitness/features/practice/practice_page_view_model.dart";
 import "package:piano_fitness/shared/models/midi_state.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:piano_fitness/shared/utils/note_utils.dart";
 import "package:piano_fitness/shared/utils/piano_range_utils.dart";
 import "package:piano_fitness/shared/widgets/midi_status_indicator.dart";

--- a/lib/features/practice/practice_page.dart
+++ b/lib/features/practice/practice_page.dart
@@ -41,9 +41,7 @@ class _PracticePageState extends State<PracticePage> {
   @override
   void initState() {
     super.initState();
-    _viewModel = PracticePageViewModel(
-      initialChannel: widget.midiChannel,
-    );
+    _viewModel = PracticePageViewModel(initialChannel: widget.midiChannel);
 
     // Initialize the ViewModel with callbacks and MIDI state
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/features/practice/practice_page_view_model.dart
+++ b/lib/features/practice/practice_page_view_model.dart
@@ -18,9 +18,8 @@ import "package:piano_fitness/shared/widgets/practice_settings_panel.dart";
 /// including MIDI data processing, practice session management, and piano range calculations.
 class PracticePageViewModel extends ChangeNotifier {
   /// Creates a new PracticePageViewModel with optional initial configuration.
-  PracticePageViewModel({
-    int initialChannel = 0,
-  }) : _midiChannel = initialChannel {
+  PracticePageViewModel({int initialChannel = 0})
+    : _midiChannel = initialChannel {
     _setupMidiListener();
   }
 

--- a/lib/features/practice/practice_page_view_model.dart
+++ b/lib/features/practice/practice_page_view_model.dart
@@ -3,6 +3,7 @@ import "package:flutter/foundation.dart";
 import "package:flutter_midi_command/flutter_midi_command.dart";
 import "package:piano/piano.dart";
 import "package:piano_fitness/shared/models/midi_state.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:piano_fitness/shared/models/practice_session.dart";
 import "package:piano_fitness/shared/services/midi_service.dart";
 import "package:piano_fitness/shared/utils/arpeggios.dart";
@@ -10,7 +11,6 @@ import "package:piano_fitness/shared/utils/note_utils.dart";
 import "package:piano_fitness/shared/utils/piano_range_utils.dart";
 import "package:piano_fitness/shared/utils/scales.dart" as music;
 import "package:piano_fitness/shared/utils/virtual_piano_utils.dart";
-import "package:piano_fitness/shared/widgets/practice_settings_panel.dart";
 
 /// ViewModel for managing practice page state and operations.
 ///

--- a/lib/shared/models/practice_mode.dart
+++ b/lib/shared/models/practice_mode.dart
@@ -28,23 +28,17 @@ extension PracticeModeJson on PracticeMode {
 
   /// Creates a [PracticeMode] from a JSON string value.
   ///
-  /// Uses [PracticeMode.values.byName] for modern Dart versions, with
-  /// fallback to manual search for compatibility.
+  /// Uses [PracticeMode.values.byName] to find the enum value by name.
   ///
   /// Throws [ArgumentError] if the provided string doesn't match any
   /// enum value.
   static PracticeMode fromJson(String json) {
     try {
-      // Use byName if available (Dart 2.15+)
       return PracticeMode.values.byName(json);
-    } catch (e) {
-      // Fallback for older Dart versions
-      for (final mode in PracticeMode.values) {
-        if (mode.name == json) {
-          return mode;
-        }
-      }
-      throw ArgumentError('Invalid PracticeMode: $json');
+    } on ArgumentError {
+      throw ArgumentError(
+        'Invalid PracticeMode: $json. Valid values are: ${PracticeMode.values.map((e) => e.name).join(', ')}',
+      );
     }
   }
 }

--- a/lib/shared/models/practice_mode.dart
+++ b/lib/shared/models/practice_mode.dart
@@ -14,3 +14,37 @@ enum PracticeMode {
   /// Practice arpeggio patterns across multiple octaves
   arpeggios,
 }
+
+/// Extension to provide JSON serialization support for [PracticeMode].
+///
+/// This extension enables converting enum values to/from strings for
+/// persistence and API communication, replacing brittle index-based
+/// serialization with robust name-based serialization.
+extension PracticeModeJson on PracticeMode {
+  /// Converts the enum value to its string name for JSON serialization.
+  ///
+  /// Returns the enum name (e.g., "scales", "chords", "arpeggios").
+  String toJson() => name;
+
+  /// Creates a [PracticeMode] from a JSON string value.
+  ///
+  /// Uses [PracticeMode.values.byName] for modern Dart versions, with
+  /// fallback to manual search for compatibility.
+  ///
+  /// Throws [ArgumentError] if the provided string doesn't match any
+  /// enum value.
+  static PracticeMode fromJson(String json) {
+    try {
+      // Use byName if available (Dart 2.15+)
+      return PracticeMode.values.byName(json);
+    } catch (e) {
+      // Fallback for older Dart versions
+      for (final mode in PracticeMode.values) {
+        if (mode.name == json) {
+          return mode;
+        }
+      }
+      throw ArgumentError('Invalid PracticeMode: $json');
+    }
+  }
+}

--- a/lib/shared/models/practice_mode.dart
+++ b/lib/shared/models/practice_mode.dart
@@ -1,0 +1,16 @@
+/// Practice modes available in the Piano Fitness app.
+///
+/// Each mode focuses on different aspects of piano technique:
+/// - [scales]: Practice major, minor, and modal scales
+/// - [chords]: Practice chord progressions and triads
+/// - [arpeggios]: Practice broken chord patterns across octaves
+enum PracticeMode {
+  /// Practice scales in various keys and modes
+  scales,
+
+  /// Practice chord progressions and triads
+  chords,
+
+  /// Practice arpeggio patterns across multiple octaves
+  arpeggios,
+}

--- a/lib/shared/models/practice_session.dart
+++ b/lib/shared/models/practice_session.dart
@@ -1,10 +1,10 @@
 import "package:flutter/foundation.dart";
 import "package:piano/piano.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:piano_fitness/shared/utils/arpeggios.dart";
 import "package:piano_fitness/shared/utils/chords.dart";
 import "package:piano_fitness/shared/utils/note_utils.dart";
 import "package:piano_fitness/shared/utils/scales.dart" as music;
-import "package:piano_fitness/shared/widgets/practice_settings_panel.dart";
 
 /// Manages the state and logic for piano practice sessions.
 ///

--- a/lib/shared/models/practice_session.dart
+++ b/lib/shared/models/practice_session.dart
@@ -273,9 +273,7 @@ class PracticeSession {
       final currentChord = _currentChordProgression[_currentChordIndex];
       final expectedChordNotes = currentChord.getMidiNotes(4).toSet();
 
-      if (expectedChordNotes.every(
-        _currentlyHeldChordNotes.contains,
-      )) {
+      if (expectedChordNotes.every(_currentlyHeldChordNotes.contains)) {
         _currentChordIndex++;
         _currentlyHeldChordNotes.clear();
 

--- a/lib/shared/models/practice_session.dart
+++ b/lib/shared/models/practice_session.dart
@@ -273,7 +273,7 @@ class PracticeSession {
       final currentChord = _currentChordProgression[_currentChordIndex];
       final expectedChordNotes = currentChord.getMidiNotes(4).toSet();
 
-      if (expectedChordNotes.every(_currentlyHeldChordNotes.contains)) {
+      if (_currentlyHeldChordNotes.containsAll(expectedChordNotes)) {
         _currentChordIndex++;
         _currentlyHeldChordNotes.clear();
 

--- a/lib/shared/utils/note_utils.dart
+++ b/lib/shared/utils/note_utils.dart
@@ -299,7 +299,7 @@ class NoteUtils {
   ///
   /// This is useful for UI elements where space is limited, such as piano key labels.
   /// The [midiNumber] must be in the valid MIDI range (0-127).
-  /// Returns just the note name (e.g., "C", "F#", "Bb").
+  /// Returns just the note name (e.g., "C", "F#", "A#").
   ///
   /// Throws [ArgumentError] if the MIDI number is outside the valid range.
   ///

--- a/lib/shared/utils/note_utils.dart
+++ b/lib/shared/utils/note_utils.dart
@@ -294,4 +294,19 @@ class NoteUtils {
   static String noteDisplayName(MusicalNote note, int octave) {
     return "${_noteToString[note]}$octave";
   }
+
+  /// Gets a compact note name without octave information.
+  ///
+  /// This is useful for UI elements where space is limited, such as piano key labels.
+  /// The [midiNumber] must be in the valid MIDI range (0-127).
+  /// Returns just the note name (e.g., "C", "F#", "Bb").
+  ///
+  /// Throws [ArgumentError] if the MIDI number is outside the valid range.
+  ///
+  /// Example: `getCompactNoteName(60)` returns "C" (for middle C).
+  /// Example: `getCompactNoteName(61)` returns "C#" (for C# above middle C).
+  static String getCompactNoteName(int midiNumber) {
+    final noteInfo = midiNumberToNote(midiNumber);
+    return _noteToString[noteInfo.note]!;
+  }
 }

--- a/lib/shared/utils/scales.dart
+++ b/lib/shared/utils/scales.dart
@@ -81,6 +81,9 @@ extension KeyDisplay on Key {
   ///
   /// For enharmonic keys (black keys), returns the more commonly used
   /// flat notation (D♭, E♭, G♭, A♭, B♭) rather than sharp notation.
+  /// This follows standard musical key signature conventions where flat
+  /// notation is preferred for most practical applications, as it aligns
+  /// with how key signatures are typically written and taught in music theory.
   String get displayName {
     switch (this) {
       case Key.c:
@@ -113,34 +116,28 @@ extension KeyDisplay on Key {
   /// Returns the full display name with enharmonic equivalent in parentheses.
   ///
   /// For natural keys (white keys), returns just the key name.
-  /// For enharmonic keys (black keys), returns the conventional name
-  /// followed by the alternative name in parentheses.
+  /// For enharmonic keys (black keys), returns the conventional flat name
+  /// followed by the sharp alternative in parentheses (e.g., "D♭ (C#)").
+  /// This provides both notations while maintaining the preference for flat
+  /// notation as the primary display format.
   String get fullDisplayName {
+    final primaryName = displayName;
+    
+    // For enharmonic keys (black keys), add the sharp alternative in parentheses
     switch (this) {
-      case Key.c:
-        return "C";
       case Key.cSharp:
-        return "D♭ (C#)";
-      case Key.d:
-        return "D";
+        return "$primaryName (C#)";
       case Key.dSharp:
-        return "E♭ (D#)";
-      case Key.e:
-        return "E";
-      case Key.f:
-        return "F";
+        return "$primaryName (D#)";
       case Key.fSharp:
-        return "G♭ (F#)";
-      case Key.g:
-        return "G";
+        return "$primaryName (F#)";
       case Key.gSharp:
-        return "A♭ (G#)";
-      case Key.a:
-        return "A";
+        return "$primaryName (G#)";
       case Key.aSharp:
-        return "B♭ (A#)";
-      case Key.b:
-        return "B";
+        return "$primaryName (A#)";
+      default:
+        // For natural keys, just return the primary name
+        return primaryName;
     }
   }
 }

--- a/lib/shared/utils/scales.dart
+++ b/lib/shared/utils/scales.dart
@@ -72,11 +72,54 @@ enum Key {
   b,
 }
 
+/// Represents the display names for a musical key.
+///
+/// This data structure co-locates the primary (conventional) name and
+/// secondary (alternative) name for each key, making it easy to verify
+/// musical conventions and maintain consistency.
+class _KeyNames {
+  const _KeyNames({
+    required this.primary,
+    this.secondary,
+  });
+
+  /// The primary/conventional display name (uses flat notation for black keys)
+  final String primary;
+  
+  /// The secondary/alternative display name (sharp notation for black keys)
+  /// Null for natural keys that have no enharmonic equivalent
+  final String? secondary;
+}
+
 /// Extension on [Key] to provide consistent display names across the app.
 ///
 /// This centralizes the logic for displaying key names and follows musical
 /// conventions for enharmonic equivalents.
 extension KeyDisplay on Key {
+  /// Mapping of keys to their display names, co-locating primary and secondary names.
+  ///
+  /// This makes it easy to verify that musical conventions are followed:
+  /// - Natural keys (C, D, E, F, G, A, B) have no secondary name
+  /// - Black keys use flat notation as primary (following key signature conventions)
+  /// - Black keys include sharp notation as secondary (alternative notation)
+  static const Map<Key, _KeyNames> _keyNameMap = {
+    // Natural keys (white keys) - no enharmonic equivalents
+    Key.c: _KeyNames(primary: "C"),
+    Key.d: _KeyNames(primary: "D"), 
+    Key.e: _KeyNames(primary: "E"),
+    Key.f: _KeyNames(primary: "F"),
+    Key.g: _KeyNames(primary: "G"),
+    Key.a: _KeyNames(primary: "A"),
+    Key.b: _KeyNames(primary: "B"),
+    
+    // Black keys (enharmonic keys) - flat primary, sharp secondary
+    Key.cSharp: _KeyNames(primary: "D♭", secondary: "C#"),
+    Key.dSharp: _KeyNames(primary: "E♭", secondary: "D#"),
+    Key.fSharp: _KeyNames(primary: "G♭", secondary: "F#"),
+    Key.gSharp: _KeyNames(primary: "A♭", secondary: "G#"),
+    Key.aSharp: _KeyNames(primary: "B♭", secondary: "A#"),
+  };
+
   /// Returns the conventional display name for the key.
   ///
   /// For enharmonic keys (black keys), returns the more commonly used
@@ -85,32 +128,7 @@ extension KeyDisplay on Key {
   /// notation is preferred for most practical applications, as it aligns
   /// with how key signatures are typically written and taught in music theory.
   String get displayName {
-    switch (this) {
-      case Key.c:
-        return "C";
-      case Key.cSharp:
-        return "D♭";
-      case Key.d:
-        return "D";
-      case Key.dSharp:
-        return "E♭";
-      case Key.e:
-        return "E";
-      case Key.f:
-        return "F";
-      case Key.fSharp:
-        return "G♭";
-      case Key.g:
-        return "G";
-      case Key.gSharp:
-        return "A♭";
-      case Key.a:
-        return "A";
-      case Key.aSharp:
-        return "B♭";
-      case Key.b:
-        return "B";
-    }
+    return _keyNameMap[this]!.primary;
   }
 
   /// Returns the full display name with enharmonic equivalent in parentheses.
@@ -121,24 +139,13 @@ extension KeyDisplay on Key {
   /// This provides both notations while maintaining the preference for flat
   /// notation as the primary display format.
   String get fullDisplayName {
-    final primaryName = displayName;
+    final keyNames = _keyNameMap[this]!;
+    final secondary = keyNames.secondary;
     
-    // For enharmonic keys (black keys), add the sharp alternative in parentheses
-    switch (this) {
-      case Key.cSharp:
-        return "$primaryName (C#)";
-      case Key.dSharp:
-        return "$primaryName (D#)";
-      case Key.fSharp:
-        return "$primaryName (F#)";
-      case Key.gSharp:
-        return "$primaryName (G#)";
-      case Key.aSharp:
-        return "$primaryName (A#)";
-      default:
-        // For natural keys, just return the primary name
-        return primaryName;
-    }
+    // If there's a secondary name (enharmonic equivalent), include it in parentheses
+    return secondary != null 
+        ? "${keyNames.primary} ($secondary)"
+        : keyNames.primary;
   }
 }
 

--- a/lib/shared/utils/scales.dart
+++ b/lib/shared/utils/scales.dart
@@ -72,6 +72,79 @@ enum Key {
   b,
 }
 
+/// Extension on [Key] to provide consistent display names across the app.
+///
+/// This centralizes the logic for displaying key names and follows musical
+/// conventions for enharmonic equivalents.
+extension KeyDisplay on Key {
+  /// Returns the conventional display name for the key.
+  ///
+  /// For enharmonic keys (black keys), returns the more commonly used
+  /// flat notation (D♭, E♭, G♭, A♭, B♭) rather than sharp notation.
+  String get displayName {
+    switch (this) {
+      case Key.c:
+        return "C";
+      case Key.cSharp:
+        return "D♭";
+      case Key.d:
+        return "D";
+      case Key.dSharp:
+        return "E♭";
+      case Key.e:
+        return "E";
+      case Key.f:
+        return "F";
+      case Key.fSharp:
+        return "G♭";
+      case Key.g:
+        return "G";
+      case Key.gSharp:
+        return "A♭";
+      case Key.a:
+        return "A";
+      case Key.aSharp:
+        return "B♭";
+      case Key.b:
+        return "B";
+    }
+  }
+
+  /// Returns the full display name with enharmonic equivalent in parentheses.
+  ///
+  /// For natural keys (white keys), returns just the key name.
+  /// For enharmonic keys (black keys), returns the conventional name
+  /// followed by the alternative name in parentheses.
+  String get fullDisplayName {
+    switch (this) {
+      case Key.c:
+        return "C";
+      case Key.cSharp:
+        return "D♭ (C#)";
+      case Key.d:
+        return "D";
+      case Key.dSharp:
+        return "E♭ (D#)";
+      case Key.e:
+        return "E";
+      case Key.f:
+        return "F";
+      case Key.fSharp:
+        return "G♭ (F#)";
+      case Key.g:
+        return "G";
+      case Key.gSharp:
+        return "A♭ (G#)";
+      case Key.a:
+        return "A";
+      case Key.aSharp:
+        return "B♭ (A#)";
+      case Key.b:
+        return "B";
+    }
+  }
+}
+
 /// Represents a musical scale with its key, type, intervals, and name.
 ///
 /// A scale defines a sequence of musical notes based on a specific pattern
@@ -239,31 +312,6 @@ class ScaleDefinitions {
   static Scale get cMajor => getScale(Key.c, ScaleType.major);
 
   static String _getKeyName(Key key) {
-    switch (key) {
-      case Key.c:
-        return "C";
-      case Key.cSharp:
-        return "C#";
-      case Key.d:
-        return "D";
-      case Key.dSharp:
-        return "D#";
-      case Key.e:
-        return "E";
-      case Key.f:
-        return "F";
-      case Key.fSharp:
-        return "F#";
-      case Key.g:
-        return "G";
-      case Key.gSharp:
-        return "G#";
-      case Key.a:
-        return "A";
-      case Key.aSharp:
-        return "A#";
-      case Key.b:
-        return "B";
-    }
+    return key.displayName;
   }
 }

--- a/lib/shared/widgets/practice_progress_display.dart
+++ b/lib/shared/widgets/practice_progress_display.dart
@@ -64,6 +64,9 @@ class PracticeProgressDisplay extends StatelessWidget {
               value: (currentNoteIndex + 1) / currentSequence.length,
               backgroundColor: Colors.blue.shade100,
               valueColor: AlwaysStoppedAnimation<Color>(Colors.blue.shade600),
+              semanticsLabel: "Scale practice progress",
+              semanticsValue:
+                  "${currentNoteIndex + 1} of ${currentSequence.length}",
             ),
           ] else if (practiceMode == PracticeMode.chords) ...[
             Text(
@@ -86,6 +89,9 @@ class PracticeProgressDisplay extends StatelessWidget {
               value: (currentChordIndex + 1) / currentChordProgression.length,
               backgroundColor: Colors.blue.shade100,
               valueColor: AlwaysStoppedAnimation<Color>(Colors.blue.shade600),
+              semanticsLabel: "Chord progression practice progress",
+              semanticsValue:
+                  "${currentChordIndex + 1} of ${currentChordProgression.length}",
             ),
           ],
         ],

--- a/lib/shared/widgets/practice_progress_display.dart
+++ b/lib/shared/widgets/practice_progress_display.dart
@@ -57,24 +57,18 @@ class PracticeProgressDisplay extends StatelessWidget {
           if (practiceMode == PracticeMode.scales) ...[
             Text(
               "Progress: ${currentNoteIndex + 1}/${currentSequence.length}",
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-              ),
+              style: const TextStyle(fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
             LinearProgressIndicator(
               value: (currentNoteIndex + 1) / currentSequence.length,
               backgroundColor: Colors.blue.shade100,
-              valueColor: AlwaysStoppedAnimation<Color>(
-                Colors.blue.shade600,
-              ),
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.blue.shade600),
             ),
           ] else if (practiceMode == PracticeMode.chords) ...[
             Text(
               "Chord ${currentChordIndex + 1}/${currentChordProgression.length}",
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-              ),
+              style: const TextStyle(fontWeight: FontWeight.bold),
             ),
             if (currentChordIndex < currentChordProgression.length) ...[
               const SizedBox(height: 4),
@@ -91,9 +85,7 @@ class PracticeProgressDisplay extends StatelessWidget {
             LinearProgressIndicator(
               value: (currentChordIndex + 1) / currentChordProgression.length,
               backgroundColor: Colors.blue.shade100,
-              valueColor: AlwaysStoppedAnimation<Color>(
-                Colors.blue.shade600,
-              ),
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.blue.shade600),
             ),
           ],
         ],

--- a/lib/shared/widgets/practice_progress_display.dart
+++ b/lib/shared/widgets/practice_progress_display.dart
@@ -1,6 +1,6 @@
 import "package:flutter/material.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:piano_fitness/shared/utils/chords.dart";
-import "package:piano_fitness/shared/widgets/practice_settings_panel.dart";
 
 /// A widget that displays progress information during active practice sessions.
 ///

--- a/lib/shared/widgets/practice_settings_panel.dart
+++ b/lib/shared/widgets/practice_settings_panel.dart
@@ -1,24 +1,8 @@
 import "package:flutter/material.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:piano_fitness/shared/utils/arpeggios.dart";
 import "package:piano_fitness/shared/utils/note_utils.dart";
 import "package:piano_fitness/shared/utils/scales.dart" as music;
-
-/// Practice modes available in the Piano Fitness app.
-///
-/// Each mode focuses on different aspects of piano technique:
-/// - [scales]: Practice major, minor, and modal scales
-/// - [chords]: Practice chord progressions and triads
-/// - [arpeggios]: Practice broken chord patterns across octaves
-enum PracticeMode {
-  /// Practice scales in various keys and modes
-  scales,
-
-  /// Practice chord progressions and triads
-  chords,
-
-  /// Practice arpeggio patterns across multiple octaves
-  arpeggios,
-}
 
 /// A comprehensive settings panel for configuring piano practice exercises.
 ///

--- a/lib/shared/widgets/practice_settings_panel.dart
+++ b/lib/shared/widgets/practice_settings_panel.dart
@@ -106,32 +106,7 @@ class PracticeSettingsPanel extends StatelessWidget {
   }
 
   String _getKeyString(music.Key key) {
-    switch (key) {
-      case music.Key.c:
-        return "C";
-      case music.Key.cSharp:
-        return "C#";
-      case music.Key.d:
-        return "D";
-      case music.Key.dSharp:
-        return "D#";
-      case music.Key.e:
-        return "E";
-      case music.Key.f:
-        return "F";
-      case music.Key.fSharp:
-        return "F#";
-      case music.Key.g:
-        return "G";
-      case music.Key.gSharp:
-        return "G#";
-      case music.Key.a:
-        return "A";
-      case music.Key.aSharp:
-        return "A#";
-      case music.Key.b:
-        return "B";
-    }
+    return key.fullDisplayName;
   }
 
   String _getScaleTypeString(music.ScaleType type) {

--- a/test/features/midi_settings/midi_settings_page_test.dart
+++ b/test/features/midi_settings/midi_settings_page_test.dart
@@ -204,9 +204,7 @@ void main() {
 
     testWidgets(
       "should display default channel when no initial channel provided",
-      (
-        tester,
-      ) async {
+      (tester) async {
         final Widget testWidget = ChangeNotifierProvider(
           create: (context) => MidiState(),
           child: const MaterialApp(home: MidiSettingsPage()),

--- a/test/features/practice/practice_page_test.dart
+++ b/test/features/practice/practice_page_test.dart
@@ -4,7 +4,7 @@ import "package:piano/piano.dart";
 import "package:piano_fitness/features/practice/practice_page.dart";
 import "package:piano_fitness/features/practice/practice_page_view_model.dart";
 import "package:piano_fitness/shared/models/midi_state.dart";
-import "package:piano_fitness/shared/widgets/practice_settings_panel.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:provider/provider.dart";
 import "../../shared/midi_mocks.dart";
 

--- a/test/features/practice/practice_page_view_model_test.dart
+++ b/test/features/practice/practice_page_view_model_test.dart
@@ -3,9 +3,9 @@ import "package:flutter_test/flutter_test.dart";
 import "package:piano/piano.dart";
 import "package:piano_fitness/features/practice/practice_page_view_model.dart";
 import "package:piano_fitness/shared/models/midi_state.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:piano_fitness/shared/utils/arpeggios.dart";
 import "package:piano_fitness/shared/utils/scales.dart" as music;
-import "package:piano_fitness/shared/widgets/practice_settings_panel.dart";
 import "../../shared/midi_mocks.dart";
 
 void main() {

--- a/test/features/practice/practice_page_view_model_test.dart
+++ b/test/features/practice/practice_page_view_model_test.dart
@@ -22,9 +22,7 @@ void main() {
     var receivedHighlightedNotes = <NotePosition>[];
 
     setUp(() {
-      viewModel = PracticePageViewModel(
-        initialChannel: 3,
-      );
+      viewModel = PracticePageViewModel(initialChannel: 3);
       mockMidiState = MidiState();
       exerciseCompletedCalled = false;
       receivedHighlightedNotes = [];

--- a/test/shared/models/practice_mode_test.dart
+++ b/test/shared/models/practice_mode_test.dart
@@ -1,0 +1,60 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:piano_fitness/shared/models/practice_mode.dart";
+
+void main() {
+  group("PracticeMode", () {
+    test("should have all expected values", () {
+      expect(PracticeMode.values.length, equals(3));
+      expect(PracticeMode.values, contains(PracticeMode.scales));
+      expect(PracticeMode.values, contains(PracticeMode.chords));
+      expect(PracticeMode.values, contains(PracticeMode.arpeggios));
+    });
+
+    test("should have correct string representation", () {
+      expect(PracticeMode.scales.toString(), equals("PracticeMode.scales"));
+      expect(PracticeMode.chords.toString(), equals("PracticeMode.chords"));
+      expect(
+        PracticeMode.arpeggios.toString(),
+        equals("PracticeMode.arpeggios"),
+      );
+    });
+
+    test("should support equality comparison", () {
+      expect(PracticeMode.scales, equals(PracticeMode.scales));
+      expect(PracticeMode.chords, equals(PracticeMode.chords));
+      expect(PracticeMode.arpeggios, equals(PracticeMode.arpeggios));
+
+      expect(PracticeMode.scales, isNot(equals(PracticeMode.chords)));
+      expect(PracticeMode.chords, isNot(equals(PracticeMode.arpeggios)));
+      expect(PracticeMode.arpeggios, isNot(equals(PracticeMode.scales)));
+    });
+
+    test("should support switch statements", () {
+      String getModeString(PracticeMode mode) {
+        switch (mode) {
+          case PracticeMode.scales:
+            return "Scales";
+          case PracticeMode.chords:
+            return "Chords";
+          case PracticeMode.arpeggios:
+            return "Arpeggios";
+        }
+      }
+
+      expect(getModeString(PracticeMode.scales), equals("Scales"));
+      expect(getModeString(PracticeMode.chords), equals("Chords"));
+      expect(getModeString(PracticeMode.arpeggios), equals("Arpeggios"));
+    });
+
+    test("should be serializable by index", () {
+      expect(PracticeMode.scales.index, equals(0));
+      expect(PracticeMode.chords.index, equals(1));
+      expect(PracticeMode.arpeggios.index, equals(2));
+
+      // Test that we can reconstruct from index
+      expect(PracticeMode.values[0], equals(PracticeMode.scales));
+      expect(PracticeMode.values[1], equals(PracticeMode.chords));
+      expect(PracticeMode.values[2], equals(PracticeMode.arpeggios));
+    });
+  });
+}

--- a/test/shared/models/practice_mode_test.dart
+++ b/test/shared/models/practice_mode_test.dart
@@ -10,7 +10,13 @@ void main() {
       expect(PracticeMode.values, contains(PracticeMode.arpeggios));
     });
 
-    test("should have correct string representation", () {
+    test("should have stable name property for serialization", () {
+      // Prefer .name over .toString() for stability and serialization
+      expect(PracticeMode.scales.name, equals("scales"));
+      expect(PracticeMode.chords.name, equals("chords"));
+      expect(PracticeMode.arpeggios.name, equals("arpeggios"));
+      
+      // toString() includes type prefix, less ideal for serialization
       expect(PracticeMode.scales.toString(), equals("PracticeMode.scales"));
       expect(PracticeMode.chords.toString(), equals("PracticeMode.chords"));
       expect(

--- a/test/shared/models/practice_mode_test.dart
+++ b/test/shared/models/practice_mode_test.dart
@@ -46,15 +46,32 @@ void main() {
       expect(getModeString(PracticeMode.arpeggios), equals("Arpeggios"));
     });
 
-    test("should be serializable by index", () {
-      expect(PracticeMode.scales.index, equals(0));
-      expect(PracticeMode.chords.index, equals(1));
-      expect(PracticeMode.arpeggios.index, equals(2));
+    test("should serialize to and from JSON correctly", () {
+      // Test toJson() returns expected string values
+      expect(PracticeMode.scales.toJson(), equals("scales"));
+      expect(PracticeMode.chords.toJson(), equals("chords"));
+      expect(PracticeMode.arpeggios.toJson(), equals("arpeggios"));
 
-      // Test that we can reconstruct from index
-      expect(PracticeMode.values[0], equals(PracticeMode.scales));
-      expect(PracticeMode.values[1], equals(PracticeMode.chords));
-      expect(PracticeMode.values[2], equals(PracticeMode.arpeggios));
+      // Test fromJson() reconstructs correct enum values
+      expect(PracticeModeJson.fromJson("scales"), equals(PracticeMode.scales));
+      expect(PracticeModeJson.fromJson("chords"), equals(PracticeMode.chords));
+      expect(
+        PracticeModeJson.fromJson("arpeggios"),
+        equals(PracticeMode.arpeggios),
+      );
+
+      // Test round-trip serialization
+      for (final mode in PracticeMode.values) {
+        final serialized = mode.toJson();
+        final deserialized = PracticeModeJson.fromJson(serialized);
+        expect(deserialized, equals(mode));
+      }
+    });
+
+    test("should handle invalid JSON gracefully", () {
+      expect(() => PracticeModeJson.fromJson("invalid"), throwsArgumentError);
+      expect(() => PracticeModeJson.fromJson(""), throwsArgumentError);
+      expect(() => PracticeModeJson.fromJson("SCALES"), throwsArgumentError);
     });
   });
 }

--- a/test/shared/utils/note_utils_test.dart
+++ b/test/shared/utils/note_utils_test.dart
@@ -273,6 +273,108 @@ void main() {
       });
     });
 
+    group("getCompactNoteName", () {
+      test("should return note names without octave", () {
+        expect(NoteUtils.getCompactNoteName(60), equals("C")); // C4
+        expect(NoteUtils.getCompactNoteName(61), equals("C#")); // C#4
+        expect(NoteUtils.getCompactNoteName(62), equals("D")); // D4
+        expect(NoteUtils.getCompactNoteName(63), equals("D#")); // D#4
+        expect(NoteUtils.getCompactNoteName(64), equals("E")); // E4
+        expect(NoteUtils.getCompactNoteName(65), equals("F")); // F4
+        expect(NoteUtils.getCompactNoteName(66), equals("F#")); // F#4
+        expect(NoteUtils.getCompactNoteName(67), equals("G")); // G4
+        expect(NoteUtils.getCompactNoteName(68), equals("G#")); // G#4
+        expect(NoteUtils.getCompactNoteName(69), equals("A")); // A4
+        expect(NoteUtils.getCompactNoteName(70), equals("A#")); // A#4
+        expect(NoteUtils.getCompactNoteName(71), equals("B")); // B4
+      });
+
+      test("should work consistently across octaves", () {
+        // Test same note across different octaves
+        expect(NoteUtils.getCompactNoteName(12), equals("C")); // C0
+        expect(NoteUtils.getCompactNoteName(24), equals("C")); // C1
+        expect(NoteUtils.getCompactNoteName(36), equals("C")); // C2
+        expect(NoteUtils.getCompactNoteName(48), equals("C")); // C3
+        expect(NoteUtils.getCompactNoteName(60), equals("C")); // C4
+        expect(NoteUtils.getCompactNoteName(72), equals("C")); // C5
+        expect(NoteUtils.getCompactNoteName(84), equals("C")); // C6
+
+        // Test sharp notes across octaves
+        expect(NoteUtils.getCompactNoteName(13), equals("C#")); // C#0
+        expect(NoteUtils.getCompactNoteName(25), equals("C#")); // C#1
+        expect(NoteUtils.getCompactNoteName(61), equals("C#")); // C#4
+        expect(NoteUtils.getCompactNoteName(85), equals("C#")); // C#6
+      });
+
+      test("should handle extreme MIDI ranges", () {
+        // Test lowest MIDI note (C-1)
+        expect(NoteUtils.getCompactNoteName(0), equals("C"));
+
+        // Test highest MIDI note (G9)
+        expect(NoteUtils.getCompactNoteName(127), equals("G"));
+
+        // Test some other extreme values
+        expect(NoteUtils.getCompactNoteName(1), equals("C#")); // C#-1
+        expect(NoteUtils.getCompactNoteName(126), equals("F#")); // F#9
+      });
+
+      test("should throw ArgumentError for invalid MIDI numbers", () {
+        expect(
+          () => NoteUtils.getCompactNoteName(-1),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              "message",
+              contains("MIDI number must be between 0 and 127"),
+            ),
+          ),
+        );
+
+        expect(
+          () => NoteUtils.getCompactNoteName(128),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              "message",
+              contains("MIDI number must be between 0 and 127"),
+            ),
+          ),
+        );
+
+        expect(
+          () => NoteUtils.getCompactNoteName(200),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              "message",
+              contains("MIDI number must be between 0 and 127"),
+            ),
+          ),
+        );
+      });
+
+      test("should be consistent with midiNumberToNote", () {
+        // Test that compact note name matches the note part of full display name
+        for (var midi = 0; midi <= 127; midi++) {
+          final fullInfo = NoteUtils.midiNumberToNote(midi);
+          final compactName = NoteUtils.getCompactNoteName(midi);
+
+          // Extract note name from full display name (remove octave and minus signs)
+          final expectedName = fullInfo.displayName.replaceAll(
+            RegExp(r"[-\d]+$"),
+            "",
+          );
+
+          expect(
+            compactName,
+            equals(expectedName),
+            reason:
+                "Compact name for MIDI $midi should match note part of ${fullInfo.displayName}",
+          );
+        }
+      });
+    });
+
     group("Bidirectional conversion", () {
       test("MIDI to note and back should be consistent", () {
         for (var midi = 0; midi <= 127; midi++) {

--- a/test/shared/utils/note_utils_test.dart
+++ b/test/shared/utils/note_utils_test.dart
@@ -121,19 +121,13 @@ void main() {
       });
 
       test("should convert flat note positions correctly", () {
-        final dFlat4 = NotePosition(
-          note: Note.D,
-          accidental: Accidental.Flat,
-        );
+        final dFlat4 = NotePosition(note: Note.D, accidental: Accidental.Flat);
         expect(
           NoteUtils.convertNotePositionToMidi(dFlat4),
           equals(61),
         ); // Same as C#
 
-        final bFlat4 = NotePosition(
-          note: Note.B,
-          accidental: Accidental.Flat,
-        );
+        final bFlat4 = NotePosition(note: Note.B, accidental: Accidental.Flat);
         expect(
           NoteUtils.convertNotePositionToMidi(bFlat4),
           equals(70),

--- a/test/shared/utils/piano_range_utils_test.dart
+++ b/test/shared/utils/piano_range_utils_test.dart
@@ -338,9 +338,7 @@ void main() {
     test("should handle custom key count", () {
       const screenWidth = 1000.0;
 
-      final keys28 = PianoRangeUtils.calculateScreenBasedKeyWidth(
-        screenWidth,
-      );
+      final keys28 = PianoRangeUtils.calculateScreenBasedKeyWidth(screenWidth);
 
       final keys35 = PianoRangeUtils.calculateScreenBasedKeyWidth(
         screenWidth,

--- a/test/shared/utils/piano_range_utils_test.dart
+++ b/test/shared/utils/piano_range_utils_test.dart
@@ -338,7 +338,10 @@ void main() {
     test("should handle custom key count", () {
       const screenWidth = 1000.0;
 
-      final keys28 = PianoRangeUtils.calculateScreenBasedKeyWidth(screenWidth);
+      final keys28 = PianoRangeUtils.calculateScreenBasedKeyWidth(
+        screenWidth,
+        keyCount: 28,
+      );
 
       final keys35 = PianoRangeUtils.calculateScreenBasedKeyWidth(
         screenWidth,

--- a/test/shared/utils/scales_test.dart
+++ b/test/shared/utils/scales_test.dart
@@ -583,13 +583,24 @@ void main() {
           final displayName = key.displayName;
           expect(displayName, isNotEmpty);
           expect(displayName, isA<String>());
-          
+
           // Verify the name contains expected musical notation
-          final isNaturalKey = ["C", "D", "E", "F", "G", "A", "B"].contains(displayName);
+          final isNaturalKey = [
+            "C",
+            "D",
+            "E",
+            "F",
+            "G",
+            "A",
+            "B",
+          ].contains(displayName);
           final isFlatKey = displayName.contains("♭");
-          
-          expect(isNaturalKey || isFlatKey, isTrue, 
-              reason: "Key $key should have either natural or flat notation");
+
+          expect(
+            isNaturalKey || isFlatKey,
+            isTrue,
+            reason: "Key $key should have either natural or flat notation",
+          );
         }
       });
     });
@@ -616,7 +627,7 @@ void main() {
       test("should show flat notation first, sharp in parentheses", () {
         for (final key in Key.values) {
           final fullName = key.fullDisplayName;
-          
+
           if (fullName.contains("(")) {
             // For enharmonic keys, verify format: "Flat (Sharp)"
             expect(fullName, matches(r"^[A-G]♭ \([A-G]#\)$"));
@@ -633,7 +644,7 @@ void main() {
           final fullDisplayName = key.fullDisplayName;
           expect(fullDisplayName, isNotEmpty);
           expect(fullDisplayName, isA<String>());
-          
+
           // Multiple calls should return same result
           expect(key.fullDisplayName, equals(fullDisplayName));
         }
@@ -646,7 +657,7 @@ void main() {
         for (final key in Key.values) {
           final scale = ScaleDefinitions.getScale(key, ScaleType.major);
           final expectedKeyName = key.displayName;
-          
+
           expect(scale.name, contains(expectedKeyName));
           expect(scale.name, endsWith(" Major (Ionian)"));
         }
@@ -657,37 +668,39 @@ void main() {
         for (final key in Key.values) {
           final displayName = key.displayName;
           final fullDisplayName = key.fullDisplayName;
-          
-          // Names should be reasonably short for UI display
-          expect(displayName.length, lessThanOrEqualTo(3));
-          expect(fullDisplayName.length, lessThanOrEqualTo(8));
-          
-          // Should not contain special characters except musical symbols
-          expect(displayName, matches(r"^[A-G♭]+$"));
+
+          // Keep names concise for UI, but avoid brittle hard caps.
+          expect(displayName, matches(r"^[A-G]$|^[A-G]♭$"));
+          // Full name either a single letter or "X♭ (Y#)"
           if (fullDisplayName.contains("(")) {
             expect(fullDisplayName, matches(r"^[A-G]♭ \([A-G]#\)$"));
           } else {
             expect(fullDisplayName, matches(r"^[A-G]$"));
           }
+
+          // Should not contain special characters except musical symbols
+          expect(displayName, matches(r"^[A-G♭]+$"));
         }
       });
 
       test("should maintain musical conventions across all keys", () {
         final expectedNaturalKeys = ["C", "D", "E", "F", "G", "A", "B"];
         final expectedFlatKeys = ["D♭", "E♭", "G♭", "A♭", "B♭"];
-        
-        final actualDisplayNames = Key.values.map((k) => k.displayName).toList();
-        
+
+        final actualDisplayNames = Key.values
+            .map((k) => k.displayName)
+            .toList();
+
         // Verify we have exactly the expected natural keys
         for (final natural in expectedNaturalKeys) {
           expect(actualDisplayNames, contains(natural));
         }
-        
+
         // Verify we have exactly the expected flat keys
         for (final flat in expectedFlatKeys) {
           expect(actualDisplayNames, contains(flat));
         }
-        
+
         // Verify total count matches enum values
         expect(actualDisplayNames.length, equals(Key.values.length));
       });
@@ -706,7 +719,7 @@ void main() {
         for (final key in Key.values) {
           final displayName = key.displayName;
           final fullDisplayName = key.fullDisplayName;
-          
+
           expect(displayName, isNotNull);
           expect(displayName, isNotEmpty);
           expect(fullDisplayName, isNotNull);
@@ -720,7 +733,7 @@ void main() {
           final name2 = key.displayName;
           final fullName1 = key.fullDisplayName;
           final fullName2 = key.fullDisplayName;
-          
+
           expect(name1, equals(name2));
           expect(fullName1, equals(fullName2));
         }

--- a/test/shared/utils/scales_test.dart
+++ b/test/shared/utils/scales_test.dart
@@ -547,4 +547,184 @@ void main() {
       });
     });
   });
+
+  group("KeyDisplay Extension", () {
+    group("displayName", () {
+      test("should return correct names for natural keys", () {
+        expect(Key.c.displayName, equals("C"));
+        expect(Key.d.displayName, equals("D"));
+        expect(Key.e.displayName, equals("E"));
+        expect(Key.f.displayName, equals("F"));
+        expect(Key.g.displayName, equals("G"));
+        expect(Key.a.displayName, equals("A"));
+        expect(Key.b.displayName, equals("B"));
+      });
+
+      test("should return flat notation for enharmonic keys", () {
+        expect(Key.cSharp.displayName, equals("D♭"));
+        expect(Key.dSharp.displayName, equals("E♭"));
+        expect(Key.fSharp.displayName, equals("G♭"));
+        expect(Key.gSharp.displayName, equals("A♭"));
+        expect(Key.aSharp.displayName, equals("B♭"));
+      });
+
+      test("should use conventional flat notation over sharp notation", () {
+        // These tests verify that the extension follows musical conventions
+        // where flat notation is preferred for key signatures
+        expect(Key.cSharp.displayName, isNot(equals("C#")));
+        expect(Key.dSharp.displayName, isNot(equals("D#")));
+        expect(Key.fSharp.displayName, isNot(equals("F#")));
+        expect(Key.gSharp.displayName, isNot(equals("G#")));
+        expect(Key.aSharp.displayName, isNot(equals("A#")));
+      });
+
+      test("should return consistent results for all keys", () {
+        for (final key in Key.values) {
+          final displayName = key.displayName;
+          expect(displayName, isNotEmpty);
+          expect(displayName, isA<String>());
+          
+          // Verify the name contains expected musical notation
+          final isNaturalKey = ["C", "D", "E", "F", "G", "A", "B"].contains(displayName);
+          final isFlatKey = displayName.contains("♭");
+          
+          expect(isNaturalKey || isFlatKey, isTrue, 
+              reason: "Key $key should have either natural or flat notation");
+        }
+      });
+    });
+
+    group("fullDisplayName", () {
+      test("should return just the key name for natural keys", () {
+        expect(Key.c.fullDisplayName, equals("C"));
+        expect(Key.d.fullDisplayName, equals("D"));
+        expect(Key.e.fullDisplayName, equals("E"));
+        expect(Key.f.fullDisplayName, equals("F"));
+        expect(Key.g.fullDisplayName, equals("G"));
+        expect(Key.a.fullDisplayName, equals("A"));
+        expect(Key.b.fullDisplayName, equals("B"));
+      });
+
+      test("should include enharmonic equivalent for black keys", () {
+        expect(Key.cSharp.fullDisplayName, equals("D♭ (C#)"));
+        expect(Key.dSharp.fullDisplayName, equals("E♭ (D#)"));
+        expect(Key.fSharp.fullDisplayName, equals("G♭ (F#)"));
+        expect(Key.gSharp.fullDisplayName, equals("A♭ (G#)"));
+        expect(Key.aSharp.fullDisplayName, equals("B♭ (A#)"));
+      });
+
+      test("should show flat notation first, sharp in parentheses", () {
+        for (final key in Key.values) {
+          final fullName = key.fullDisplayName;
+          
+          if (fullName.contains("(")) {
+            // For enharmonic keys, verify format: "Flat (Sharp)"
+            expect(fullName, matches(r"^[A-G]♭ \([A-G]#\)$"));
+            expect(fullName.indexOf("♭"), lessThan(fullName.indexOf("#")));
+          } else {
+            // For natural keys, verify single letter format
+            expect(fullName, matches(r"^[A-G]$"));
+          }
+        }
+      });
+
+      test("should be consistent for all keys", () {
+        for (final key in Key.values) {
+          final fullDisplayName = key.fullDisplayName;
+          expect(fullDisplayName, isNotEmpty);
+          expect(fullDisplayName, isA<String>());
+          
+          // Multiple calls should return same result
+          expect(key.fullDisplayName, equals(fullDisplayName));
+        }
+      });
+    });
+
+    group("KeyDisplay integration", () {
+      test("should integrate properly with scale name generation", () {
+        // Test that the extension works correctly when used in ScaleDefinitions
+        for (final key in Key.values) {
+          final scale = ScaleDefinitions.getScale(key, ScaleType.major);
+          final expectedKeyName = key.displayName;
+          
+          expect(scale.name, contains(expectedKeyName));
+          expect(scale.name, endsWith(" Major (Ionian)"));
+        }
+      });
+
+      test("should provide readable names for user interfaces", () {
+        // Test that names are appropriate for display in UI
+        for (final key in Key.values) {
+          final displayName = key.displayName;
+          final fullDisplayName = key.fullDisplayName;
+          
+          // Names should be reasonably short for UI display
+          expect(displayName.length, lessThanOrEqualTo(3));
+          expect(fullDisplayName.length, lessThanOrEqualTo(8));
+          
+          // Should not contain special characters except musical symbols
+          expect(displayName, matches(r"^[A-G♭]+$"));
+          if (fullDisplayName.contains("(")) {
+            expect(fullDisplayName, matches(r"^[A-G]♭ \([A-G]#\)$"));
+          } else {
+            expect(fullDisplayName, matches(r"^[A-G]$"));
+          }
+        }
+      });
+
+      test("should maintain musical conventions across all keys", () {
+        final expectedNaturalKeys = ["C", "D", "E", "F", "G", "A", "B"];
+        final expectedFlatKeys = ["D♭", "E♭", "G♭", "A♭", "B♭"];
+        
+        final actualDisplayNames = Key.values.map((k) => k.displayName).toList();
+        
+        // Verify we have exactly the expected natural keys
+        for (final natural in expectedNaturalKeys) {
+          expect(actualDisplayNames, contains(natural));
+        }
+        
+        // Verify we have exactly the expected flat keys
+        for (final flat in expectedFlatKeys) {
+          expect(actualDisplayNames, contains(flat));
+        }
+        
+        // Verify total count matches enum values
+        expect(actualDisplayNames.length, equals(Key.values.length));
+      });
+    });
+
+    group("Edge cases and validation", () {
+      test("should handle all Key enum values", () {
+        // Ensure no Key values are missing from the extension
+        for (final key in Key.values) {
+          expect(() => key.displayName, returnsNormally);
+          expect(() => key.fullDisplayName, returnsNormally);
+        }
+      });
+
+      test("should return non-null, non-empty strings", () {
+        for (final key in Key.values) {
+          final displayName = key.displayName;
+          final fullDisplayName = key.fullDisplayName;
+          
+          expect(displayName, isNotNull);
+          expect(displayName, isNotEmpty);
+          expect(fullDisplayName, isNotNull);
+          expect(fullDisplayName, isNotEmpty);
+        }
+      });
+
+      test("should be deterministic across multiple calls", () {
+        for (final key in Key.values) {
+          final name1 = key.displayName;
+          final name2 = key.displayName;
+          final fullName1 = key.fullDisplayName;
+          final fullName2 = key.fullDisplayName;
+          
+          expect(name1, equals(name2));
+          expect(fullName1, equals(fullName2));
+        }
+      });
+    });
+  });
 }


### PR DESCRIPTION
Introduce extensions for musical keys to improve readability and maintainability. Include the musical flats where relevant, to follow key spelling conventions. Refactor existing code for better formatting and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PracticeMode enum with JSON serialization and NoteUtils.getCompactNoteName; practice sessions now mark completion at end of a chord progression.

- **Refactor**
  - Centralized key/note naming (flat-first display, optional sharp) and updated UI to use shared naming utilities.

- **Style**
  - Widespread formatting and line-wrapping cleanups across pages, widgets, and view models.

- **Tests**
  - Expanded tests for key/display naming, compact note names, practice mode, piano range, and related integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->