### PR TITLE
Enable auto-start on MIDI input and replace Snackbar with custom overlay

### DIFF
--- a/lib/features/practice/practice_page.dart
+++ b/lib/features/practice/practice_page.dart
@@ -70,13 +70,55 @@ class _PracticePageState extends State<PracticePage> {
   }
 
   void _completeExercise() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text("Exercise completed! Well done!"),
-        backgroundColor: Colors.green,
-        duration: Duration(seconds: 3),
+    // Use a custom overlay approach to show completion message at top
+    final overlay = Overlay.of(context);
+    late OverlayEntry overlayEntry;
+
+    overlayEntry = OverlayEntry(
+      builder: (context) => Positioned(
+        top: MediaQuery.of(context).padding.top + 20,
+        left: 20,
+        right: 20,
+        child: Material(
+          color: Colors.transparent,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            decoration: BoxDecoration(
+              color: Colors.green,
+              borderRadius: BorderRadius.circular(8),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.1),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.check_circle, color: Colors.white),
+                SizedBox(width: 8),
+                Text(
+                  "Exercise completed! Well done!",
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
+
+    overlay.insert(overlayEntry);
+
+    // Remove the overlay after 2 seconds
+    Future.delayed(const Duration(seconds: 2), () {
+      overlayEntry.remove();
+    });
   }
 
   void _startPractice() {

--- a/lib/features/practice/practice_page.dart
+++ b/lib/features/practice/practice_page.dart
@@ -80,7 +80,8 @@ class _PracticePageState extends State<PracticePage> {
   }
 
   void _startPractice() {
-    _viewModel.startPractice();
+    // No-op: Practice now auto-starts on MIDI input
+    // This method kept for backward compatibility only
   }
 
   void _resetPractice() {

--- a/lib/features/practice/practice_page.dart
+++ b/lib/features/practice/practice_page.dart
@@ -121,11 +121,6 @@ class _PracticePageState extends State<PracticePage> {
     });
   }
 
-  void _startPractice() {
-    // No-op: Practice now auto-starts on MIDI input
-    // This method kept for backward compatibility only
-  }
-
   void _resetPractice() {
     _viewModel.resetPractice();
   }
@@ -188,7 +183,6 @@ class _PracticePageState extends State<PracticePage> {
                           selectedChordProgression:
                               session.selectedChordProgression,
                           practiceActive: session.practiceActive,
-                          onStartPractice: _startPractice,
                           onResetPractice: _resetPractice,
                           onPracticeModeChanged: (mode) {
                             _viewModel.setPracticeMode(mode);

--- a/lib/features/practice/practice_page_view_model.dart
+++ b/lib/features/practice/practice_page_view_model.dart
@@ -115,6 +115,11 @@ class PracticePageViewModel extends ChangeNotifier {
         case MidiEventType.noteOn:
           _localMidiState.noteOn(event.data1, event.data2, event.channel);
           if (_practiceSession != null) {
+            // Auto-start practice on first MIDI note if not already active
+            if (!_practiceSession!.practiceActive) {
+              _practiceSession!.startPractice();
+              notifyListeners();
+            }
             _practiceSession?.handleNotePressed(event.data1);
           }
           break;
@@ -191,6 +196,12 @@ class PracticePageViewModel extends ChangeNotifier {
   /// Plays a virtual note through MIDI output and triggers practice session.
   Future<void> playVirtualNote(int note, {bool mounted = true}) async {
     if (_practiceSession == null) return;
+
+    // Auto-start practice on virtual note if not already active
+    if (!_practiceSession!.practiceActive) {
+      _practiceSession!.startPractice();
+      notifyListeners();
+    }
 
     await VirtualPianoUtils.playVirtualNote(
       note,

--- a/lib/features/practice/practice_page_view_model.dart
+++ b/lib/features/practice/practice_page_view_model.dart
@@ -118,7 +118,6 @@ class PracticePageViewModel extends ChangeNotifier {
             // Auto-start practice on first MIDI note if not already active
             if (!_practiceSession!.practiceActive) {
               _practiceSession!.startPractice();
-              notifyListeners();
             }
             _practiceSession?.handleNotePressed(event.data1);
           }
@@ -200,7 +199,6 @@ class PracticePageViewModel extends ChangeNotifier {
     // Auto-start practice on virtual note if not already active
     if (!_practiceSession!.practiceActive) {
       _practiceSession!.startPractice();
-      notifyListeners();
     }
 
     await VirtualPianoUtils.playVirtualNote(

--- a/lib/shared/models/practice_session.dart
+++ b/lib/shared/models/practice_session.dart
@@ -340,7 +340,6 @@ class PracticeSession {
 
   void _completeExercise() {
     _practiceActive = false;
-    onHighlightedNotesChanged([]);
     onExerciseCompleted();
 
     // Reset for immediate repetition - ready for next practice session

--- a/lib/shared/models/practice_session.dart
+++ b/lib/shared/models/practice_session.dart
@@ -342,6 +342,12 @@ class PracticeSession {
     _practiceActive = false;
     onHighlightedNotesChanged([]);
     onExerciseCompleted();
+
+    // Reset for immediate repetition - ready for next practice session
+    _currentNoteIndex = 0;
+    _currentChordIndex = 0;
+    _currentlyHeldChordNotes.clear();
+    _updateHighlightedNotes();
   }
 
   /// Generates a MIDI note sequence from a list of ChordInfo objects.
@@ -378,6 +384,7 @@ class PracticeSession {
   ///
   /// Stops the active session and resets all progress indicators.
   /// The exercise configuration (mode, key, type) remains unchanged.
+  /// Ready for immediate repetition when next note is played.
   void resetPractice() {
     _practiceActive = false;
     _currentNoteIndex = 0;

--- a/lib/shared/widgets/practice_settings_panel.dart
+++ b/lib/shared/widgets/practice_settings_panel.dart
@@ -347,45 +347,51 @@ class PracticeSettingsPanel extends StatelessWidget {
           // Show practice status and reset button
           Column(
             children: [
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  vertical: 8,
-                  horizontal: 12,
-                ),
-                decoration: BoxDecoration(
-                  color: practiceActive
-                      ? Colors.green.shade100
-                      : Colors.blue.shade50,
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(
-                    color: practiceActive
-                        ? Colors.green.shade300
-                        : Colors.blue.shade200,
+              Semantics(
+                liveRegion: true,
+                label: practiceActive
+                    ? "Practice Active - Keep Playing!"
+                    : "Ready - Play Any Note to Start",
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 8,
+                    horizontal: 12,
                   ),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      practiceActive ? Icons.music_note : Icons.piano,
+                  decoration: BoxDecoration(
+                    color: practiceActive
+                        ? Colors.green.shade100
+                        : Colors.blue.shade50,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
                       color: practiceActive
-                          ? Colors.green.shade700
-                          : Colors.blue.shade700,
-                      size: 20,
+                          ? Colors.green.shade300
+                          : Colors.blue.shade200,
                     ),
-                    const SizedBox(width: 8),
-                    Text(
-                      practiceActive
-                          ? "Practice Active - Keep Playing!"
-                          : "Ready - Play Any Note to Start",
-                      style: TextStyle(
-                        fontWeight: FontWeight.w500,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        practiceActive ? Icons.music_note : Icons.piano,
                         color: practiceActive
                             ? Colors.green.shade700
                             : Colors.blue.shade700,
+                        size: 20,
                       ),
-                    ),
-                  ],
+                      const SizedBox(width: 8),
+                      Text(
+                        practiceActive
+                            ? "Practice Active - Keep Playing!"
+                            : "Ready - Play Any Note to Start",
+                        style: TextStyle(
+                          fontWeight: FontWeight.w500,
+                          color: practiceActive
+                              ? Colors.green.shade700
+                              : Colors.blue.shade700,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
               const SizedBox(height: 12),

--- a/lib/shared/widgets/practice_settings_panel.dart
+++ b/lib/shared/widgets/practice_settings_panel.dart
@@ -61,6 +61,8 @@ class PracticeSettingsPanel extends StatelessWidget {
   final bool practiceActive;
 
   /// Callback fired when the user taps the Start button.
+  /// NOTE: Start button removed - practice auto-starts on MIDI input.
+  @Deprecated("Auto-start enabled - start button no longer needed")
   final VoidCallback onStartPractice;
 
   /// Callback fired when the user taps the Reset button.
@@ -348,22 +350,55 @@ class PracticeSettingsPanel extends StatelessWidget {
             ),
           ],
           const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          // Show practice status and reset button
+          Column(
             children: [
-              ElevatedButton.icon(
-                onPressed: practiceActive ? null : onStartPractice,
-                icon: const Icon(Icons.play_arrow),
-                label: const Text("Start"),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.green,
-                  foregroundColor: Colors.white,
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  vertical: 8,
+                  horizontal: 12,
+                ),
+                decoration: BoxDecoration(
+                  color: practiceActive
+                      ? Colors.green.shade100
+                      : Colors.blue.shade50,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: practiceActive
+                        ? Colors.green.shade300
+                        : Colors.blue.shade200,
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      practiceActive ? Icons.music_note : Icons.piano,
+                      color: practiceActive
+                          ? Colors.green.shade700
+                          : Colors.blue.shade700,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      practiceActive
+                          ? "Practice Active - Keep Playing!"
+                          : "Ready - Play Any Note to Start",
+                      style: TextStyle(
+                        fontWeight: FontWeight.w500,
+                        color: practiceActive
+                            ? Colors.green.shade700
+                            : Colors.blue.shade700,
+                      ),
+                    ),
+                  ],
                 ),
               ),
+              const SizedBox(height: 12),
               ElevatedButton.icon(
                 onPressed: onResetPractice,
                 icon: const Icon(Icons.refresh),
-                label: const Text("Reset"),
+                label: const Text("Reset Exercise"),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.orange,
                   foregroundColor: Colors.white,

--- a/lib/shared/widgets/practice_settings_panel.dart
+++ b/lib/shared/widgets/practice_settings_panel.dart
@@ -11,7 +11,7 @@ import "package:piano_fitness/shared/utils/scales.dart" as music;
 /// musical keys, scale types, and other exercise-specific parameters. It adapts its
 /// interface based on the selected practice mode to show relevant options.
 class PracticeSettingsPanel extends StatelessWidget {
-  /// Creates a practice settings panel with all required configuration options.
+  /// Creates a practice settings panel with configuration options for practice sessions.
   ///
   /// All parameters are required to ensure the panel can properly display
   /// current settings and handle user interactions.
@@ -24,7 +24,6 @@ class PracticeSettingsPanel extends StatelessWidget {
     required this.selectedArpeggioOctaves,
     required this.selectedChordProgression,
     required this.practiceActive,
-    required this.onStartPractice,
     required this.onResetPractice,
     required this.onPracticeModeChanged,
     required this.onKeyChanged,
@@ -59,11 +58,6 @@ class PracticeSettingsPanel extends StatelessWidget {
 
   /// Whether a practice session is currently active.
   final bool practiceActive;
-
-  /// Callback fired when the user taps the Start button.
-  /// NOTE: Start button removed - practice auto-starts on MIDI input.
-  @Deprecated("Auto-start enabled - start button no longer needed")
-  final VoidCallback onStartPractice;
 
   /// Callback fired when the user taps the Reset button.
   final VoidCallback onResetPractice;


### PR DESCRIPTION
Implement auto-start functionality for practice sessions triggered by MIDI input and enhance user feedback by replacing the Snackbar with a custom overlay message for exercise completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Practice auto-starts on first MIDI or virtual note input; no manual start needed.
  - New top-aligned success overlay confirms exercise completion and fades after 2 seconds.
  - Status indicator shows Active/Ready states with contextual colors and icons.

- Changes
  - Start button removed from practice settings; Reset button relabeled to “Reset Exercise.”
  - Exercise progress now resets immediately on completion for seamless repetition.

- Documentation
  - Notes added clarifying immediate-repeat readiness after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->