### PR TITLE
Add new "Chords by Type" practice mode

### DIFF
--- a/lib/features/practice/practice_hub_page.dart
+++ b/lib/features/practice/practice_hub_page.dart
@@ -110,12 +110,14 @@ class PracticeHubPage extends StatelessWidget {
                     Expanded(
                       child: _buildPracticeModeCard(
                         context,
-                        title: "Chords",
+                        title: "Chords by Key",
                         icon: Icons.piano,
                         description: "Individual chord triads and inversions",
                         color: Colors.green,
-                        onTap: () =>
-                            _navigateToPractice(context, PracticeMode.chords),
+                        onTap: () => _navigateToPractice(
+                          context,
+                          PracticeMode.chordsByKey,
+                        ),
                       ),
                     ),
                     const SizedBox(width: 8),

--- a/lib/features/practice/practice_hub_page.dart
+++ b/lib/features/practice/practice_hub_page.dart
@@ -91,6 +91,7 @@ class PracticeHubPage extends StatelessWidget {
               ),
               const SizedBox(height: 16),
 
+              // First row of practice modes
               IntrinsicHeight(
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -124,6 +125,31 @@ class PracticeHubPage extends StatelessWidget {
                     Expanded(
                       child: _buildPracticeModeCard(
                         context,
+                        title: "Chords by Type",
+                        icon: Icons.library_music,
+                        description:
+                            "Major, minor, diminished, augmented chords",
+                        color: Colors.teal,
+                        onTap: () => _navigateToPractice(
+                          context,
+                          PracticeMode.chordsByType,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: 12),
+
+              // Second row of practice modes
+              IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: _buildPracticeModeCard(
+                        context,
                         title: "Arpeggios",
                         icon: Icons.swap_vert,
                         description:
@@ -149,6 +175,10 @@ class PracticeHubPage extends StatelessWidget {
                           PracticeMode.chordProgressions,
                         ),
                       ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Container(), // Empty placeholder for symmetry
                     ),
                   ],
                 ),

--- a/lib/features/practice/practice_page.dart
+++ b/lib/features/practice/practice_page.dart
@@ -182,6 +182,8 @@ class _PracticePageState extends State<PracticePage> {
                               session.selectedArpeggioOctaves,
                           selectedChordProgression:
                               session.selectedChordProgression,
+                          selectedChordType: session.selectedChordType,
+                          includeInversions: session.includeInversions,
                           practiceActive: session.practiceActive,
                           onResetPractice: _resetPractice,
                           onPracticeModeChanged: (mode) {
@@ -204,6 +206,12 @@ class _PracticePageState extends State<PracticePage> {
                           },
                           onChordProgressionChanged: (progression) {
                             _viewModel.setSelectedChordProgression(progression);
+                          },
+                          onChordTypeChanged: (type) {
+                            _viewModel.setSelectedChordType(type);
+                          },
+                          onIncludeInversionsChanged: (include) {
+                            _viewModel.setIncludeInversions(include);
                           },
                         );
                       },

--- a/lib/features/practice/practice_page_view_model.dart
+++ b/lib/features/practice/practice_page_view_model.dart
@@ -9,6 +9,7 @@ import "package:piano_fitness/shared/models/practice_session.dart";
 import "package:piano_fitness/shared/services/midi_connection_service.dart";
 import "package:piano_fitness/shared/services/midi_service.dart";
 import "package:piano_fitness/shared/utils/arpeggios.dart";
+import "package:piano_fitness/shared/utils/chords.dart";
 import "package:piano_fitness/shared/utils/note_utils.dart";
 import "package:piano_fitness/shared/utils/piano_range_utils.dart";
 import "package:piano_fitness/shared/utils/scales.dart" as music;
@@ -189,6 +190,18 @@ class PracticePageViewModel extends ChangeNotifier {
   /// Changes the selected chord progression type and updates the session.
   void setSelectedChordProgression(ChordProgression progression) {
     _practiceSession?.setSelectedChordProgression(progression);
+    notifyListeners();
+  }
+
+  /// Changes the selected chord type and updates the session.
+  void setSelectedChordType(ChordType type) {
+    _practiceSession?.setSelectedChordType(type);
+    notifyListeners();
+  }
+
+  /// Changes the include inversions setting and updates the session.
+  void setIncludeInversions(bool includeInversions) {
+    _practiceSession?.setIncludeInversions(includeInversions);
     notifyListeners();
   }
 

--- a/lib/shared/models/practice_mode.dart
+++ b/lib/shared/models/practice_mode.dart
@@ -3,6 +3,7 @@
 /// Each mode focuses on different aspects of piano technique:
 /// - [scales]: Practice major, minor, and modal scales
 /// - [chordsByKey]: Practice individual chord triads and inversions
+/// - [chordsByType]: Practice specific chord types (major, minor, diminished, augmented)
 /// - [arpeggios]: Practice broken chord patterns across octaves
 /// - [chordProgressions]: Practice chord progressions using roman numeral notation
 enum PracticeMode {
@@ -11,6 +12,9 @@ enum PracticeMode {
 
   /// Practice individual chord triads and inversions
   chordsByKey,
+
+  /// Practice specific chord types (major, minor, diminished, augmented)
+  chordsByType,
 
   /// Practice arpeggio patterns across multiple octaves
   arpeggios,
@@ -27,7 +31,7 @@ enum PracticeMode {
 extension PracticeModeJson on PracticeMode {
   /// Converts the enum value to its string name for JSON serialization.
   ///
-  /// Returns the enum name (e.g., "scales", "chordsByKey", "arpeggios").
+  /// Returns the enum name (e.g., "scales", "chordsByKey", "chordsByType", "arpeggios").
   String toJson() => name;
 
   /// Creates a [PracticeMode] from a JSON string value.

--- a/lib/shared/models/practice_mode.dart
+++ b/lib/shared/models/practice_mode.dart
@@ -2,7 +2,7 @@
 ///
 /// Each mode focuses on different aspects of piano technique:
 /// - [scales]: Practice major, minor, and modal scales
-/// - [chords]: Practice individual chord triads and inversions
+/// - [chordsByKey]: Practice individual chord triads and inversions
 /// - [arpeggios]: Practice broken chord patterns across octaves
 /// - [chordProgressions]: Practice chord progressions using roman numeral notation
 enum PracticeMode {
@@ -10,7 +10,7 @@ enum PracticeMode {
   scales,
 
   /// Practice individual chord triads and inversions
-  chords,
+  chordsByKey,
 
   /// Practice arpeggio patterns across multiple octaves
   arpeggios,
@@ -27,7 +27,7 @@ enum PracticeMode {
 extension PracticeModeJson on PracticeMode {
   /// Converts the enum value to its string name for JSON serialization.
   ///
-  /// Returns the enum name (e.g., "scales", "chords", "arpeggios").
+  /// Returns the enum name (e.g., "scales", "chordsByKey", "arpeggios").
   String toJson() => name;
 
   /// Creates a [PracticeMode] from a JSON string value.

--- a/lib/shared/models/practice_session.dart
+++ b/lib/shared/models/practice_session.dart
@@ -170,7 +170,7 @@ class PracticeSession {
       _currentSequence = scale.getFullScaleSequence(4);
       _currentNoteIndex = 0;
       _updateHighlightedNotes();
-    } else if (_practiceMode == PracticeMode.chords) {
+    } else if (_practiceMode == PracticeMode.chordsByKey) {
       _currentChordProgression = ChordDefinitions.getSmoothKeyTriadProgression(
         _selectedKey,
         _selectedScaleType,
@@ -242,7 +242,7 @@ class PracticeSession {
         noteInfo.octave,
       );
       onHighlightedNotesChanged([notePosition]);
-    } else if (_practiceMode == PracticeMode.chords ||
+    } else if (_practiceMode == PracticeMode.chordsByKey ||
         _practiceMode == PracticeMode.chordProgressions) {
       if (_currentChordIndex < _currentChordProgression.length) {
         final currentChord = _currentChordProgression[_currentChordIndex];
@@ -291,7 +291,7 @@ class PracticeSession {
           _updateHighlightedNotes();
         }
       }
-    } else if (_practiceMode == PracticeMode.chords ||
+    } else if (_practiceMode == PracticeMode.chordsByKey ||
         _practiceMode == PracticeMode.chordProgressions) {
       if (_currentChordIndex < _currentChordProgression.length) {
         final currentChord = _currentChordProgression[_currentChordIndex];
@@ -313,7 +313,7 @@ class PracticeSession {
   ///
   /// The [midiNote] parameter should be the MIDI note number (0-127).
   void handleNoteReleased(int midiNote) {
-    if ((_practiceMode == PracticeMode.chords ||
+    if ((_practiceMode == PracticeMode.chordsByKey ||
             _practiceMode == PracticeMode.chordProgressions) &&
         _practiceActive) {
       _currentlyHeldChordNotes.remove(midiNote);

--- a/lib/shared/utils/chords.dart
+++ b/lib/shared/utils/chords.dart
@@ -382,3 +382,181 @@ class ChordDefinitions {
     return midiSequence;
   }
 }
+
+/// Represents a chord planing practice exercise focusing on a specific chord type.
+///
+/// Chord planing involves practicing the same chord type (major, minor, diminished,
+/// augmented) across all 12 chromatic root notes in sequence. This technique helps
+/// students develop consistent chord recognition and fingering patterns while
+/// understanding how chord qualities sound in different harmonic contexts.
+class ChordByType {
+  /// Creates a new ChordByType practice exercise.
+  const ChordByType({
+    required this.type,
+    required this.rootNotes,
+    required this.includeInversions,
+    required this.name,
+  });
+
+  /// The chord type to practice (major, minor, diminished, augmented).
+  final ChordType type;
+
+  /// List of root notes to practice this chord type on.
+  final List<MusicalNote> rootNotes;
+
+  /// Whether to include chord inversions in the practice sequence.
+  final bool includeInversions;
+
+  /// The human-readable name of this practice exercise.
+  final String name;
+
+  /// Generates the complete practice sequence for this chord type.
+  ///
+  /// Returns a list of [ChordInfo] objects representing all chords
+  /// in the practice sequence, optionally including inversions.
+  List<ChordInfo> generateChordSequence() {
+    final chords = <ChordInfo>[];
+
+    for (final rootNote in rootNotes) {
+      // Add root position
+      chords.add(
+        ChordDefinitions.getChord(rootNote, type, ChordInversion.root),
+      );
+
+      if (includeInversions) {
+        // Add inversions
+        chords.add(
+          ChordDefinitions.getChord(rootNote, type, ChordInversion.first),
+        );
+        chords.add(
+          ChordDefinitions.getChord(rootNote, type, ChordInversion.second),
+        );
+      }
+    }
+
+    return chords;
+  }
+
+  /// Returns the complete MIDI note sequence for this chord type practice.
+  ///
+  /// Generates MIDI note numbers for all chords in the sequence,
+  /// starting from the specified octave.
+  List<int> getMidiSequence(int startOctave) {
+    final chords = generateChordSequence();
+    final midiSequence = <int>[];
+
+    for (final chord in chords) {
+      midiSequence.addAll(chord.getMidiNotes(startOctave));
+    }
+
+    return midiSequence;
+  }
+}
+
+/// Provides static definitions and factory methods for creating chord planing exercises.
+///
+/// This class focuses on chord planing - practicing specific chord types across all
+/// 12 chromatic root notes. This complements key-based chord practice by emphasizing
+/// intervallic patterns, chord quality recognition, and consistent fingering across keys.
+class ChordByTypeDefinitions {
+  /// Common chord type names for display purposes.
+  static const Map<ChordType, String> _typeDisplayNames = {
+    ChordType.major: "Major Chords",
+    ChordType.minor: "Minor Chords",
+    ChordType.diminished: "Diminished Chords",
+    ChordType.augmented: "Augmented Chords",
+  };
+
+  /// All 12 chromatic root notes for chord planing practice.
+  static const List<MusicalNote> _chromaticRootNotes = [
+    MusicalNote.c,
+    MusicalNote.cSharp,
+    MusicalNote.d,
+    MusicalNote.dSharp,
+    MusicalNote.e,
+    MusicalNote.f,
+    MusicalNote.fSharp,
+    MusicalNote.g,
+    MusicalNote.gSharp,
+    MusicalNote.a,
+    MusicalNote.aSharp,
+    MusicalNote.b,
+  ];
+
+  /// Creates a chord planing exercise for the specified chord type.
+  ///
+  /// Chord planing involves practicing the same chord type across all 12 chromatic
+  /// root notes in sequence, which helps students learn to recognize and play
+  /// chord qualities consistently across different keys.
+  ///
+  /// [type] - The chord type to practice across all keys
+  /// [includeInversions] - Whether to include chord inversions
+  static ChordByType getChordTypeExercise(
+    ChordType type, {
+    bool includeInversions = true,
+  }) {
+    final typeName = _typeDisplayNames[type]!;
+    final inversionSuffix = includeInversions ? " (with inversions)" : "";
+
+    return ChordByType(
+      type: type,
+      rootNotes:
+          _chromaticRootNotes, // Always use all 12 keys for chord planing
+      includeInversions: includeInversions,
+      name: "$typeName$inversionSuffix - All 12 Keys",
+    );
+  }
+
+  /// Returns a practice exercise for major chords.
+  static ChordByType getMajorChordExercise({bool includeInversions = true}) {
+    return getChordTypeExercise(
+      ChordType.major,
+      includeInversions: includeInversions,
+    );
+  }
+
+  /// Returns a practice exercise for minor chords.
+  static ChordByType getMinorChordExercise({bool includeInversions = true}) {
+    return getChordTypeExercise(
+      ChordType.minor,
+      includeInversions: includeInversions,
+    );
+  }
+
+  /// Returns a practice exercise for diminished chords.
+  static ChordByType getDiminishedChordExercise({
+    bool includeInversions = true,
+  }) {
+    return getChordTypeExercise(
+      ChordType.diminished,
+      includeInversions: includeInversions,
+    );
+  }
+
+  /// Returns a practice exercise for augmented chords.
+  static ChordByType getAugmentedChordExercise({
+    bool includeInversions = true,
+  }) {
+    return getChordTypeExercise(
+      ChordType.augmented,
+      includeInversions: includeInversions,
+    );
+  }
+
+  /// Returns all basic chord type exercises (major, minor, diminished, augmented).
+  static List<ChordByType> getAllBasicChordTypeExercises({
+    bool includeInversions = true,
+  }) {
+    return [
+      getMajorChordExercise(includeInversions: includeInversions),
+      getMinorChordExercise(includeInversions: includeInversions),
+      getDiminishedChordExercise(includeInversions: includeInversions),
+      getAugmentedChordExercise(includeInversions: includeInversions),
+    ];
+  }
+
+  /// Returns the display name for a chord type.
+  static String getChordTypeDisplayName(ChordType type) {
+    return _typeDisplayNames[type] ?? "Unknown Chord Type";
+  }
+}

--- a/lib/shared/widgets/practice_progress_display.dart
+++ b/lib/shared/widgets/practice_progress_display.dart
@@ -71,10 +71,10 @@ class PracticeProgressDisplay extends StatelessWidget {
               semanticsValue:
                   "${currentNoteIndex + 1} of ${currentSequence.length}",
             ),
-          ] else if (practiceMode == PracticeMode.chords ||
+          ] else if (practiceMode == PracticeMode.chordsByKey ||
               practiceMode == PracticeMode.chordProgressions) ...[
             Text(
-              practiceMode == PracticeMode.chords
+              practiceMode == PracticeMode.chordsByKey
                   ? "Chord ${currentChordIndex + 1}/${currentChordProgression.length}"
                   : "Progression ${currentChordIndex + 1}/${currentChordProgression.length}",
               style: const TextStyle(fontWeight: FontWeight.bold),
@@ -95,7 +95,7 @@ class PracticeProgressDisplay extends StatelessWidget {
               value: (currentChordIndex + 1) / currentChordProgression.length,
               backgroundColor: Colors.blue.shade100,
               valueColor: AlwaysStoppedAnimation<Color>(Colors.blue.shade600),
-              semanticsLabel: practiceMode == PracticeMode.chords
+              semanticsLabel: practiceMode == PracticeMode.chordsByKey
                   ? "Chord practice progress"
                   : "Chord progression practice progress",
               semanticsValue:

--- a/lib/shared/widgets/practice_progress_display.dart
+++ b/lib/shared/widgets/practice_progress_display.dart
@@ -72,9 +72,12 @@ class PracticeProgressDisplay extends StatelessWidget {
                   "${currentNoteIndex + 1} of ${currentSequence.length}",
             ),
           ] else if (practiceMode == PracticeMode.chordsByKey ||
+              practiceMode == PracticeMode.chordsByType ||
               practiceMode == PracticeMode.chordProgressions) ...[
             Text(
               practiceMode == PracticeMode.chordsByKey
+                  ? "Chord ${currentChordIndex + 1}/${currentChordProgression.length}"
+                  : practiceMode == PracticeMode.chordsByType
                   ? "Chord ${currentChordIndex + 1}/${currentChordProgression.length}"
                   : "Progression ${currentChordIndex + 1}/${currentChordProgression.length}",
               style: const TextStyle(fontWeight: FontWeight.bold),
@@ -97,6 +100,8 @@ class PracticeProgressDisplay extends StatelessWidget {
               valueColor: AlwaysStoppedAnimation<Color>(Colors.blue.shade600),
               semanticsLabel: practiceMode == PracticeMode.chordsByKey
                   ? "Chord practice progress"
+                  : practiceMode == PracticeMode.chordsByType
+                  ? "Chord type practice progress"
                   : "Chord progression practice progress",
               semanticsValue:
                   "${currentChordIndex + 1} of ${currentChordProgression.length}",

--- a/lib/shared/widgets/practice_settings_panel.dart
+++ b/lib/shared/widgets/practice_settings_panel.dart
@@ -87,8 +87,8 @@ class PracticeSettingsPanel extends StatelessWidget {
     switch (mode) {
       case PracticeMode.scales:
         return "Scales";
-      case PracticeMode.chords:
-        return "Chords";
+      case PracticeMode.chordsByKey:
+        return "Chords by Key";
       case PracticeMode.arpeggios:
         return "Arpeggios";
       case PracticeMode.chordProgressions:

--- a/lib/shared/widgets/practice_settings_panel.dart
+++ b/lib/shared/widgets/practice_settings_panel.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:piano_fitness/shared/models/chord_progression_type.dart";
 import "package:piano_fitness/shared/models/practice_mode.dart";
 import "package:piano_fitness/shared/utils/arpeggios.dart";
+import "package:piano_fitness/shared/utils/chords.dart";
 import "package:piano_fitness/shared/utils/note_utils.dart";
 import "package:piano_fitness/shared/utils/scales.dart" as music;
 
@@ -23,6 +24,8 @@ class PracticeSettingsPanel extends StatelessWidget {
     required this.selectedArpeggioType,
     required this.selectedArpeggioOctaves,
     required this.selectedChordProgression,
+    required this.selectedChordType,
+    required this.includeInversions,
     required this.practiceActive,
     required this.onResetPractice,
     required this.onPracticeModeChanged,
@@ -32,6 +35,8 @@ class PracticeSettingsPanel extends StatelessWidget {
     required this.onArpeggioTypeChanged,
     required this.onArpeggioOctavesChanged,
     required this.onChordProgressionChanged,
+    required this.onChordTypeChanged,
+    required this.onIncludeInversionsChanged,
     super.key,
   });
 
@@ -55,6 +60,12 @@ class PracticeSettingsPanel extends StatelessWidget {
 
   /// The selected chord progression type for chord progression exercises.
   final ChordProgression? selectedChordProgression;
+
+  /// The selected chord type for chord type exercises.
+  final ChordType selectedChordType;
+
+  /// Whether to include inversions in chord type exercises.
+  final bool includeInversions;
 
   /// Whether a practice session is currently active.
   final bool practiceActive;
@@ -83,12 +94,20 @@ class PracticeSettingsPanel extends StatelessWidget {
   /// Callback fired when the user changes the chord progression type.
   final ValueChanged<ChordProgression> onChordProgressionChanged;
 
+  /// Callback fired when the user changes the chord type.
+  final ValueChanged<ChordType> onChordTypeChanged;
+
+  /// Callback fired when the user changes the inversion setting.
+  final ValueChanged<bool> onIncludeInversionsChanged;
+
   String _getPracticeModeString(PracticeMode mode) {
     switch (mode) {
       case PracticeMode.scales:
         return "Scales";
       case PracticeMode.chordsByKey:
         return "Chords by Key";
+      case PracticeMode.chordsByType:
+        return "Chords by Type";
       case PracticeMode.arpeggios:
         return "Arpeggios";
       case PracticeMode.chordProgressions:
@@ -155,6 +174,19 @@ class PracticeSettingsPanel extends StatelessWidget {
 
   String _getChordProgressionString(ChordProgression? progression) {
     return progression?.displayName ?? "Select Progression";
+  }
+
+  String _getChordTypeString(ChordType type) {
+    switch (type) {
+      case ChordType.major:
+        return "Major";
+      case ChordType.minor:
+        return "Minor";
+      case ChordType.diminished:
+        return "Diminished";
+      case ChordType.augmented:
+        return "Augmented";
+    }
   }
 
   @override
@@ -227,6 +259,25 @@ class PracticeSettingsPanel extends StatelessWidget {
                         onChanged: (value) {
                           if (value != null) {
                             onRootNoteChanged(value);
+                          }
+                        },
+                      )
+                    : practiceMode == PracticeMode.chordsByType
+                    ? DropdownButtonFormField<ChordType>(
+                        initialValue: selectedChordType,
+                        decoration: const InputDecoration(
+                          labelText: "Chord Type",
+                          border: OutlineInputBorder(),
+                        ),
+                        items: ChordType.values.map((type) {
+                          return DropdownMenuItem(
+                            value: type,
+                            child: Text(_getChordTypeString(type)),
+                          );
+                        }).toList(),
+                        onChanged: (value) {
+                          if (value != null) {
+                            onChordTypeChanged(value);
                           }
                         },
                       )
@@ -341,6 +392,20 @@ class PracticeSettingsPanel extends StatelessWidget {
                   onChordProgressionChanged(value);
                 }
               },
+            ),
+          ],
+          if (practiceMode == PracticeMode.chordsByType) ...[
+            const SizedBox(height: 12),
+            CheckboxListTile(
+              title: const Text("Include Inversions"),
+              subtitle: const Text("Add 1st and 2nd inversions"),
+              value: includeInversions,
+              onChanged: (value) {
+                if (value != null) {
+                  onIncludeInversionsChanged(value);
+                }
+              },
+              controlAffinity: ListTileControlAffinity.leading,
             ),
           ],
           const SizedBox(height: 16),

--- a/test/features/practice/practice_hub_page_test.dart
+++ b/test/features/practice/practice_hub_page_test.dart
@@ -47,7 +47,7 @@ void main() {
       // Check that practice mode cards are present
       expect(find.text("Practice Modes"), findsOneWidget);
       expect(find.text("Scales"), findsOneWidget);
-      expect(find.text("Chords"), findsOneWidget);
+      expect(find.text("Chords by Key"), findsOneWidget);
       expect(find.text("Arpeggios"), findsOneWidget);
       expect(find.text("Chord Progressions"), findsOneWidget);
 

--- a/test/features/practice/practice_hub_page_test.dart
+++ b/test/features/practice/practice_hub_page_test.dart
@@ -48,6 +48,7 @@ void main() {
       expect(find.text("Practice Modes"), findsOneWidget);
       expect(find.text("Scales"), findsOneWidget);
       expect(find.text("Chords by Key"), findsOneWidget);
+      expect(find.text("Chords by Type"), findsOneWidget);
       expect(find.text("Arpeggios"), findsOneWidget);
       expect(find.text("Chord Progressions"), findsOneWidget);
 

--- a/test/features/practice/practice_page_view_model_test.dart
+++ b/test/features/practice/practice_page_view_model_test.dart
@@ -99,11 +99,11 @@ void main() {
         ..addListener(() {
           notificationReceived = true;
         })
-        ..setPracticeMode(PracticeMode.chords);
+        ..setPracticeMode(PracticeMode.chordsByKey);
 
       expect(
         viewModel.practiceSession!.practiceMode,
-        equals(PracticeMode.chords),
+        equals(PracticeMode.chordsByKey),
       );
       expect(notificationReceived, isTrue);
     });
@@ -299,7 +299,7 @@ void main() {
       test("should handle all practice mode changes", () {
         final modes = [
           PracticeMode.scales,
-          PracticeMode.chords,
+          PracticeMode.chordsByKey,
           PracticeMode.arpeggios,
         ];
 

--- a/test/shared/models/practice_mode_test.dart
+++ b/test/shared/models/practice_mode_test.dart
@@ -6,7 +6,7 @@ void main() {
     test("should have all expected values", () {
       expect(PracticeMode.values.length, equals(4));
       expect(PracticeMode.values, contains(PracticeMode.scales));
-      expect(PracticeMode.values, contains(PracticeMode.chords));
+      expect(PracticeMode.values, contains(PracticeMode.chordsByKey));
       expect(PracticeMode.values, contains(PracticeMode.arpeggios));
       expect(PracticeMode.values, contains(PracticeMode.chordProgressions));
     });
@@ -14,13 +14,16 @@ void main() {
     test("should have stable name property for serialization", () {
       // Prefer .name over .toString() for stability and serialization
       expect(PracticeMode.scales.name, equals("scales"));
-      expect(PracticeMode.chords.name, equals("chords"));
+      expect(PracticeMode.chordsByKey.name, equals("chordsByKey"));
       expect(PracticeMode.arpeggios.name, equals("arpeggios"));
       expect(PracticeMode.chordProgressions.name, equals("chordProgressions"));
 
       // toString() includes type prefix, less ideal for serialization
       expect(PracticeMode.scales.toString(), equals("PracticeMode.scales"));
-      expect(PracticeMode.chords.toString(), equals("PracticeMode.chords"));
+      expect(
+        PracticeMode.chordsByKey.toString(),
+        equals("PracticeMode.chordsByKey"),
+      );
       expect(
         PracticeMode.arpeggios.toString(),
         equals("PracticeMode.arpeggios"),
@@ -33,11 +36,11 @@ void main() {
 
     test("should support equality comparison", () {
       expect(PracticeMode.scales, equals(PracticeMode.scales));
-      expect(PracticeMode.chords, equals(PracticeMode.chords));
+      expect(PracticeMode.chordsByKey, equals(PracticeMode.chordsByKey));
       expect(PracticeMode.arpeggios, equals(PracticeMode.arpeggios));
 
-      expect(PracticeMode.scales, isNot(equals(PracticeMode.chords)));
-      expect(PracticeMode.chords, isNot(equals(PracticeMode.arpeggios)));
+      expect(PracticeMode.scales, isNot(equals(PracticeMode.chordsByKey)));
+      expect(PracticeMode.chordsByKey, isNot(equals(PracticeMode.arpeggios)));
       expect(PracticeMode.arpeggios, isNot(equals(PracticeMode.scales)));
     });
 
@@ -46,7 +49,7 @@ void main() {
         switch (mode) {
           case PracticeMode.scales:
             return "Scales";
-          case PracticeMode.chords:
+          case PracticeMode.chordsByKey:
             return "Chords";
           case PracticeMode.arpeggios:
             return "Arpeggios";
@@ -56,7 +59,7 @@ void main() {
       }
 
       expect(getModeString(PracticeMode.scales), equals("Scales"));
-      expect(getModeString(PracticeMode.chords), equals("Chords"));
+      expect(getModeString(PracticeMode.chordsByKey), equals("Chords"));
       expect(getModeString(PracticeMode.arpeggios), equals("Arpeggios"));
       expect(
         getModeString(PracticeMode.chordProgressions),
@@ -67,7 +70,7 @@ void main() {
     test("should serialize to and from JSON correctly", () {
       // Test toJson() returns expected string values
       expect(PracticeMode.scales.toJson(), equals("scales"));
-      expect(PracticeMode.chords.toJson(), equals("chords"));
+      expect(PracticeMode.chordsByKey.toJson(), equals("chordsByKey"));
       expect(PracticeMode.arpeggios.toJson(), equals("arpeggios"));
       expect(
         PracticeMode.chordProgressions.toJson(),
@@ -76,7 +79,10 @@ void main() {
 
       // Test fromJson() reconstructs correct enum values
       expect(PracticeModeJson.fromJson("scales"), equals(PracticeMode.scales));
-      expect(PracticeModeJson.fromJson("chords"), equals(PracticeMode.chords));
+      expect(
+        PracticeModeJson.fromJson("chordsByKey"),
+        equals(PracticeMode.chordsByKey),
+      );
       expect(
         PracticeModeJson.fromJson("arpeggios"),
         equals(PracticeMode.arpeggios),

--- a/test/shared/models/practice_mode_test.dart
+++ b/test/shared/models/practice_mode_test.dart
@@ -4,9 +4,10 @@ import "package:piano_fitness/shared/models/practice_mode.dart";
 void main() {
   group("PracticeMode", () {
     test("should have all expected values", () {
-      expect(PracticeMode.values.length, equals(4));
+      expect(PracticeMode.values.length, equals(5));
       expect(PracticeMode.values, contains(PracticeMode.scales));
       expect(PracticeMode.values, contains(PracticeMode.chordsByKey));
+      expect(PracticeMode.values, contains(PracticeMode.chordsByType));
       expect(PracticeMode.values, contains(PracticeMode.arpeggios));
       expect(PracticeMode.values, contains(PracticeMode.chordProgressions));
     });
@@ -15,6 +16,7 @@ void main() {
       // Prefer .name over .toString() for stability and serialization
       expect(PracticeMode.scales.name, equals("scales"));
       expect(PracticeMode.chordsByKey.name, equals("chordsByKey"));
+      expect(PracticeMode.chordsByType.name, equals("chordsByType"));
       expect(PracticeMode.arpeggios.name, equals("arpeggios"));
       expect(PracticeMode.chordProgressions.name, equals("chordProgressions"));
 
@@ -23,6 +25,10 @@ void main() {
       expect(
         PracticeMode.chordsByKey.toString(),
         equals("PracticeMode.chordsByKey"),
+      );
+      expect(
+        PracticeMode.chordsByType.toString(),
+        equals("PracticeMode.chordsByType"),
       );
       expect(
         PracticeMode.arpeggios.toString(),
@@ -37,6 +43,7 @@ void main() {
     test("should support equality comparison", () {
       expect(PracticeMode.scales, equals(PracticeMode.scales));
       expect(PracticeMode.chordsByKey, equals(PracticeMode.chordsByKey));
+      expect(PracticeMode.chordsByType, equals(PracticeMode.chordsByType));
       expect(PracticeMode.arpeggios, equals(PracticeMode.arpeggios));
 
       expect(PracticeMode.scales, isNot(equals(PracticeMode.chordsByKey)));
@@ -51,6 +58,8 @@ void main() {
             return "Scales";
           case PracticeMode.chordsByKey:
             return "Chords";
+          case PracticeMode.chordsByType:
+            return "Chord Types";
           case PracticeMode.arpeggios:
             return "Arpeggios";
           case PracticeMode.chordProgressions:
@@ -60,6 +69,7 @@ void main() {
 
       expect(getModeString(PracticeMode.scales), equals("Scales"));
       expect(getModeString(PracticeMode.chordsByKey), equals("Chords"));
+      expect(getModeString(PracticeMode.chordsByType), equals("Chord Types"));
       expect(getModeString(PracticeMode.arpeggios), equals("Arpeggios"));
       expect(
         getModeString(PracticeMode.chordProgressions),
@@ -71,6 +81,7 @@ void main() {
       // Test toJson() returns expected string values
       expect(PracticeMode.scales.toJson(), equals("scales"));
       expect(PracticeMode.chordsByKey.toJson(), equals("chordsByKey"));
+      expect(PracticeMode.chordsByType.toJson(), equals("chordsByType"));
       expect(PracticeMode.arpeggios.toJson(), equals("arpeggios"));
       expect(
         PracticeMode.chordProgressions.toJson(),
@@ -82,6 +93,10 @@ void main() {
       expect(
         PracticeModeJson.fromJson("chordsByKey"),
         equals(PracticeMode.chordsByKey),
+      );
+      expect(
+        PracticeModeJson.fromJson("chordsByType"),
+        equals(PracticeMode.chordsByType),
       );
       expect(
         PracticeModeJson.fromJson("arpeggios"),

--- a/test/shared/utils/chord_by_type_test.dart
+++ b/test/shared/utils/chord_by_type_test.dart
@@ -1,0 +1,168 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:piano_fitness/shared/utils/chords.dart";
+import "package:piano_fitness/shared/utils/note_utils.dart";
+
+void main() {
+  group("ChordByType - Chord Planing", () {
+    test("should generate chord planing sequence across all 12 keys", () {
+      final majorChordExercise = ChordByTypeDefinitions.getMajorChordExercise(
+        includeInversions: false,
+      );
+
+      expect(majorChordExercise.type, equals(ChordType.major));
+      expect(majorChordExercise.includeInversions, isFalse);
+      expect(majorChordExercise.name, contains("Major Chords"));
+      expect(majorChordExercise.name, contains("All 12 Keys"));
+
+      final chords = majorChordExercise.generateChordSequence();
+
+      // Should have 12 chords for all chromatic keys, no inversions
+      expect(chords.length, equals(12));
+
+      // All chords should be major type
+      for (final chord in chords) {
+        expect(chord.type, equals(ChordType.major));
+        expect(chord.inversion, equals(ChordInversion.root));
+      }
+
+      // Should contain all 12 chromatic roots
+      final uniqueRootNotes = chords.map((chord) => chord.rootNote).toSet();
+      expect(uniqueRootNotes.length, equals(12));
+      expect(uniqueRootNotes, contains(MusicalNote.c));
+      expect(uniqueRootNotes, contains(MusicalNote.cSharp));
+      expect(uniqueRootNotes, contains(MusicalNote.fSharp));
+      expect(uniqueRootNotes, contains(MusicalNote.b));
+    });
+
+    test("should generate chord planing with inversions for all 12 keys", () {
+      final minorChordExercise = ChordByTypeDefinitions.getMinorChordExercise();
+
+      expect(minorChordExercise.type, equals(ChordType.minor));
+      expect(minorChordExercise.includeInversions, isTrue);
+      expect(minorChordExercise.name, contains("All 12 Keys"));
+
+      final chords = minorChordExercise.generateChordSequence();
+
+      // Should have 36 chords (12 root notes × 3 positions each)
+      expect(chords.length, equals(36));
+
+      // First three chords should be C minor in different inversions
+      expect(chords[0].rootNote, equals(MusicalNote.c));
+      expect(chords[0].type, equals(ChordType.minor));
+      expect(chords[0].inversion, equals(ChordInversion.root));
+      expect(chords[1].rootNote, equals(MusicalNote.c));
+      expect(chords[1].type, equals(ChordType.minor));
+      expect(chords[1].inversion, equals(ChordInversion.first));
+      expect(chords[2].rootNote, equals(MusicalNote.c));
+      expect(chords[2].type, equals(ChordType.minor));
+      expect(chords[2].inversion, equals(ChordInversion.second));
+
+      // Should include all 12 chromatic root notes
+      final uniqueRootNotes = chords.map((chord) => chord.rootNote).toSet();
+      expect(uniqueRootNotes.length, equals(12));
+    });
+
+    test("should demonstrate chord planing concept with augmented chords", () {
+      final augmentedChordExercise =
+          ChordByTypeDefinitions.getAugmentedChordExercise(
+            includeInversions: false,
+          );
+
+      final chords = augmentedChordExercise.generateChordSequence();
+
+      // Should have 12 chords for all chromatic notes
+      expect(chords.length, equals(12));
+
+      // Should include both natural and sharp/flat notes
+      final rootNotes = chords.map((chord) => chord.rootNote).toSet();
+      expect(rootNotes.contains(MusicalNote.c), isTrue);
+      expect(rootNotes.contains(MusicalNote.cSharp), isTrue);
+      expect(rootNotes.contains(MusicalNote.fSharp), isTrue);
+    });
+
+    test("should generate MIDI sequence for chord planing practice", () {
+      final majorChordExercise = ChordByTypeDefinitions.getMajorChordExercise(
+        includeInversions: false,
+      );
+
+      final midiSequence = majorChordExercise.getMidiSequence(4);
+
+      // Should have MIDI notes for all chords in the planing sequence
+      expect(midiSequence, isNotEmpty);
+
+      // 12 chromatic chords × 3 notes each (major triads)
+      expect(midiSequence.length, equals(36));
+
+      // First three notes should be C major chord in octave 4
+      expect(midiSequence[0], equals(60)); // C4
+      expect(midiSequence[1], equals(64)); // E4
+      expect(midiSequence[2], equals(67)); // G4
+
+      // Next three should be C# major (61, 65, 68)
+      expect(midiSequence[3], equals(61)); // C#4
+      expect(midiSequence[4], equals(65)); // F4 (E#)
+      expect(midiSequence[5], equals(68)); // G#4
+    });
+  });
+
+  group("ChordByTypeDefinitions - Factory Methods", () {
+    test("should return all basic chord type exercises", () {
+      final allExercises =
+          ChordByTypeDefinitions.getAllBasicChordTypeExercises();
+
+      expect(allExercises.length, equals(4));
+
+      final types = allExercises.map((ex) => ex.type).toSet();
+      expect(types.contains(ChordType.major), isTrue);
+      expect(types.contains(ChordType.minor), isTrue);
+      expect(types.contains(ChordType.diminished), isTrue);
+      expect(types.contains(ChordType.augmented), isTrue);
+    });
+
+    test("should provide correct display names", () {
+      expect(
+        ChordByTypeDefinitions.getChordTypeDisplayName(ChordType.major),
+        equals("Major Chords"),
+      );
+      expect(
+        ChordByTypeDefinitions.getChordTypeDisplayName(ChordType.minor),
+        equals("Minor Chords"),
+      );
+      expect(
+        ChordByTypeDefinitions.getChordTypeDisplayName(ChordType.diminished),
+        equals("Diminished Chords"),
+      );
+      expect(
+        ChordByTypeDefinitions.getChordTypeDisplayName(ChordType.augmented),
+        equals("Augmented Chords"),
+      );
+    });
+
+    test(
+      "should create different chord planing exercises based on inversions",
+      () {
+        final basicMajor = ChordByTypeDefinitions.getMajorChordExercise(
+          includeInversions: false,
+        );
+
+        final advancedMajor = ChordByTypeDefinitions.getMajorChordExercise();
+
+        expect(basicMajor.includeInversions, isFalse);
+        expect(advancedMajor.includeInversions, isTrue);
+
+        // Both should use all 12 keys for complete chord planing
+        expect(basicMajor.rootNotes.length, equals(12));
+        expect(advancedMajor.rootNotes.length, equals(12));
+
+        expect(basicMajor.name, contains("All 12 Keys"));
+        expect(advancedMajor.name, contains("All 12 Keys"));
+
+        // Basic should have 12 chords (root position only)
+        expect(basicMajor.generateChordSequence().length, equals(12));
+
+        // Advanced should have 36 chords (12 keys × 3 inversions each)
+        expect(advancedMajor.generateChordSequence().length, equals(36));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Change "Chords" terminology to "Chords by Key" and introduce a new practice mode "Chords by Type" with related functionality.