### PR TITLE
Refactor practice strategies to utilize PracticeNote for MIDI note handling

### DIFF
--- a/docs/specifications/exercise-sequence.md
+++ b/docs/specifications/exercise-sequence.md
@@ -1,0 +1,389 @@
+<!--
+  Status: Draft
+  Created: 2026-07-19
+  Last updated: 2026-07-19
+-->
+
+# Exercise Sequence Specification
+
+## Overview
+
+`PracticeExercise` is the immutable musical material consumed by the practice
+transport. It is analogous to a MIDI clip in a DAW: the exercise contains the
+ordered score, while `PracticeSession` owns the playhead, held-note state, and
+advancement behavior.
+
+The existing model names already fit this purpose:
+
+```text
+PracticeExercise
+└── ordered PracticeStep values
+    └── simultaneous PracticeNote targets
+```
+
+```text
+PracticeExercise = (S1, S2, …, Sk)
+Si               = {n1, n2, …, nr}
+n                = (pitch, hand, finger?, annotations)
+```
+
+Order belongs to `PracticeExercise`. Simultaneity belongs to `PracticeStep`.
+Pitch and note-level guidance belong together in `PracticeNote`.
+
+This is a focused internal refactor, not a replacement exercise system.
+`PracticeExercise`, `PracticeStep`, `PracticeStrategy`, and `PracticeSession`
+remain in their current architectural roles. The principal model change is that
+a step owns complete note-target values instead of storing pitch, hand, and
+finger in parallel structures.
+
+## Goals
+
+- **Consolidated model**: Keep pitch, intended hand, optional finger, and
+  note-level annotations in one immutable value object.
+- **Sequencer behavior**: Treat an exercise as ordered onset steps and each step
+  as the notes intended to begin together.
+- **Broad pedagogy**: Support single hand, hands together, independent hands,
+  single tones, blocked sonorities, broken textures, and permutations without
+  family-specific runtime models.
+- **Small delta**: Retain the existing top-level models, generator interface,
+  transport, and step metadata that already work.
+- **One runtime representation**: Do not zip parallel pitch, hand, or finger
+  arrays in evaluation or presentation.
+
+## Domain Model
+
+### PracticeNote
+
+`PracticeNote` is an immutable note-target value object. It owns:
+
+- a validated `MidiNote` pitch;
+- exactly one intended hand, left or right;
+- an optional finger number from 1 through 5; and
+- optional note-level annotations such as enharmonic spelling, scale degree,
+  harmonic role, help text, or structural identity.
+
+The intended hand uses a two-valued note-hand type. `HandSelection.both` remains
+useful when configuring an exercise, but it is not a valid hand for one note
+target.
+
+`PracticeNote` equality includes its target and guidance. Evaluation compares
+only MIDI pitches because ordinary MIDI input cannot report a physical hand or
+finger.
+
+### PracticeStep
+
+`PracticeStep` is one ordered onset moment. Its `notes` collection contains
+complete `PracticeNote` values intended to begin together.
+
+- A runnable step contains at least one note.
+- Notes are stored in deterministic order for serialization and display, but
+  their order has no performance meaning within the step.
+- The notes are semantically a set.
+- A MIDI pitch may occur only once in a step. Standard MIDI input cannot
+  distinguish two same-pitch targets assigned to different hands.
+- A hand may not assign one finger to two notes in the same step.
+- Expected MIDI pitches are derived directly from `PracticeStep.notes`.
+- Step-level data such as chord label, harmonic function, instruction, or
+  display name remains in the existing step metadata; it is not duplicated on
+  every note.
+- Note-level `hand` and `fingers` metadata is removed after those values move
+  into `PracticeNote`.
+
+`StepType` is removed. A step is simultaneous by definition, so the type does
+not add information:
+
+- sequential material is represented by multiple ordered singleton steps;
+- hands-together material is represented by one step containing both hands'
+  notes; and
+- a blocked chord is represented by one step containing all chord notes.
+
+All steps therefore use the same expected-pitch-set evaluation rule.
+
+### PracticeExercise
+
+`PracticeExercise` remains the top-level immutable sequence. It owns:
+
+- an ordered collection of `PracticeStep` values; and
+- exercise-level metadata such as exercise family, key, mode, difficulty, or
+  display description.
+
+Its existing operations remain conceptually valid:
+
+- step access by playhead position;
+- `length`, `isEmpty`, and `isNotEmpty`;
+- collecting all pitches for keyboard range calculation;
+- copying, equality, and deterministic JSON serialization.
+
+Those operations are updated to traverse `PracticeNote.pitch` rather than raw
+integer note lists. No `PracticeSequence` wrapper or replacement type is added.
+
+## Transport Behavior
+
+`PracticeSession` remains the transport controller. It owns the current step
+index, active/complete state, and currently held MIDI pitches. The immutable
+`PracticeExercise` does not own mutable playhead state.
+
+- Guidance highlights every `PracticeNote.pitch` in the current step.
+- Self-paced evaluation compares currently held MIDI pitches with the current
+  step's expected pitch set.
+- A step completes only when the pitch sets are equal; unexpected held pitches
+  prevent advancement.
+- The playhead advances by one step and never interprets note ordering within a
+  step.
+- Transport logic does not branch on whether an exercise originated as a scale,
+  chord, cadence, arpeggio, or authored drill.
+- Hand and finger remain guidance only; they are not evaluated from MIDI input.
+
+The MIDI/DAW analogy is structural rather than clock-based in V1. Steps advance
+through successful self-paced input, not elapsed time. Duration, tempo, release,
+and pedal can be added later without changing the ordered-step hierarchy.
+
+## Unified Pedagogical Representations
+
+| Exercise family | `PracticeExercise` representation |
+| --- | --- |
+| Single-hand scale | Singleton steps whose notes all name the selected hand. |
+| Hands-together scale | Each step contains left- and right-hand notes. |
+| Blocked chord | One step contains all chord notes. |
+| Broken chord or arpeggio | Chord notes occur in successive singleton steps. |
+| Arpeggio plus bass | Some steps contain bass and right-hand notes; intervening steps contain right-hand notes only. |
+| Mixed accompaniment | Blocked and singleton steps occur in one exercise. |
+| Voiced chord progression | Each chord is a step of individually guided notes. |
+| Independent hands | Each step contains whichever hand has an onset; neither hand must occur in every step. |
+| Repeated technical drill | Repetition is repeated subsequences with distinct structural occurrence IDs when persistence requires them. |
+
+A right-hand scale fragment is:
+
+```text
+(
+  { (60, right, 1) },
+  { (62, right, 2) },
+  { (64, right, 3) },
+  { (65, right, 1) }
+)
+```
+
+A hands-together scale fragment is:
+
+```text
+(
+  { (48, left, 5), (60, right, 1) },
+  { (50, left, 4), (62, right, 2) },
+  { (52, left, 3), (64, right, 3) }
+)
+```
+
+An arpeggio with unequal hand density is:
+
+```text
+(
+  { (36, left, 5), (48, left, 1), (60, right, 1) },
+  { (64, right, 2) },
+  { (67, right, 3) },
+  { (72, right, 5) },
+  { (43, left, 5), (55, left, 1), (67, right, 3) },
+  { (64, right, 2) },
+  { (60, right, 1) }
+)
+```
+
+No blocked-chord, arpeggio, hands-together, or independent-hands runtime subtype
+is necessary. Those distinctions belong to generation and presentation.
+
+## Ordering and Permutations
+
+There is no performance permutation inside one blocked step. All of its notes
+begin together:
+
+```text
+{ (60, right, 1), (64, right, 3), (67, right, 5) }
+```
+
+To arpeggiate the same material, a generator emits ordered singleton steps:
+
+```text
+root–third–fifth             fifth–third–root
+
+{ (60, right, 1) }        { (67, right, 5) }
+{ (64, right, 3) }        { (64, right, 3) }
+{ (67, right, 5) }        { (60, right, 1) }
+```
+
+If a generator recalculates fingering for a permutation, it preserves the
+pitch-hand content but produces new guided `PracticeNote` values. Fingering is
+part of target guidance, not MIDI evaluation.
+
+## Generators and Combinators
+
+Existing music-theory services and `PracticeStrategy` implementations remain
+the family-specific generators. `PracticeStrategy.initializeExercise()` still
+returns `PracticeExercise`; the returned steps now contain complete notes.
+
+The generation space includes independent choices along these axes:
+
+| Axis | Supported forms |
+| --- | --- |
+| Hand allocation | Left, right, hands together, alternating, and independent hands with unequal onset density. |
+| Texture | Single tone, interval, blocked multi-tone group, broken group, and mixtures within one exercise. |
+| Sequence shape | Ascending, descending, mirrored, repeated, concatenated, transposed, and selected permutations. |
+| Coordination | Parallel motion, contrary motion, one-hand-only steps, and explicitly merged onsets. |
+| Guidance | Finger, spelling, harmonic role, structural ID, and help annotations attached to the appropriate object. |
+
+Reusable pure operations may:
+
+- convert a note collection into singleton steps in a chosen order;
+- keep a note collection together as one blocked step;
+- concatenate, repeat, reverse, transpose, or select permutations;
+- merge explicitly aligned left- and right-hand onsets while retaining unpaired
+  onsets from either hand;
+- assign or recalculate hands, fingers, spelling, and structural identity; and
+- validate the resulting `PracticeExercise`.
+
+Operations return new immutable values and preserve guidance and identity unless
+their contract explicitly recalculates them. Combinatoric generation must be
+bounded by pedagogical intent: callers select a particular order, constrained
+family, sample, or maximum count rather than materializing every factorial
+permutation.
+
+This does not require an upfront exercise DSL. A reusable operation should be
+extracted when an existing strategy and another concrete exercise need the same
+transformation.
+
+## Alignment With the Current Codebase
+
+The current implementation already supplies most required behavior:
+
+- `PracticeExercise` already owns ordered `PracticeStep` values.
+- All `PracticeStrategy` implementations already return that common model.
+- Scale and arpeggio strategies already emit singleton or two-note
+  hands-together onset steps.
+- Chord and progression strategies already emit blocked onset steps.
+- `PracticeSession` already owns the playhead and tracks held pitches as a set.
+- The UI already highlights the current step and displays fingering.
+
+The delta is deliberately narrow:
+
+| Existing area | Focused change |
+| --- | --- |
+| `PracticeExercise` and its role | Update traversal and JSON for complete notes. |
+| `PracticeStep` and its role | Change `notes` from raw MIDI integers to `PracticeNote` values. |
+| `PracticeStrategy.initializeExercise()` | Construct complete notes directly. |
+| `PracticeSession` as transport | Evaluate every step through exact pitch-set equality. |
+| `StepType` | Remove the enum, field, constructor argument, JSON value, and evaluation branches. |
+| Exercise- and step-level metadata | Remove only note-level hand/finger entries. |
+
+No `PracticeSequence`, parallel `hands` array, compatibility adapter, or second
+persisted object graph is introduced.
+
+## Implementation Plan
+
+### Phase 1 — Lock Existing Musical Output
+
+**Goal**: Preserve musical behavior while changing the internal note shape.
+
+- Add focused tests for every existing strategy's pitches, hands, fingers, and
+  step order.
+- Add invariant tests for MIDI range, finger range, non-empty steps, and unique
+  in-step pitches.
+
+### Phase 2 — Consolidate PracticeStep Notes
+
+**Goal**: Establish the cohesive note-target model.
+
+- Add `PracticeNote` and the two-valued note-hand type in the domain layer.
+- Change `PracticeStep.notes` to contain complete `PracticeNote` values.
+- Move hand and finger guidance out of raw metadata.
+- Remove `StepType` from the domain model and serialized step shape.
+- Update `PracticeStep` and `PracticeExercise` equality, copying, pitch access,
+  range collection, and JSON.
+- Keep `PracticeExercise`, `PracticeStep`, and
+  `PracticeStrategy.initializeExercise()` otherwise intact.
+
+### Phase 3 — Update Existing Generators
+
+**Goal**: Preserve every existing exercise using the consolidated model.
+
+- Update scales, arpeggios, chords, progressions, and cadences to construct
+  `PracticeNote` directly.
+- Preserve current step order, pitches, hand assignments, fingering, labels,
+  harmonic descriptions, and exercise metadata.
+- Delete generation of note-level hand and finger metadata.
+
+### Phase 4 — Update Transport and Presentation
+
+**Goal**: Consume complete notes without runtime reconstruction.
+
+- Update `PracticeSession` to derive exact pitch sets from current-step notes.
+- Replace the three type-based evaluation branches with one pitch-set
+  completion rule.
+- Update highlighting, range calculation, fingering, and accessibility code to
+  read `PracticeNote` directly.
+- Derive pitch-only integer collections only at MIDI or keyboard API boundaries.
+
+### Phase 5 — Expand the Generator Space
+
+**Goal**: Add richer pedagogy without further transport changes.
+
+- Add mixed accompaniment, arpeggio-plus-bass, hands-independent, and bounded
+  permutation generators.
+- Extract shared pure combinators only after concrete reuse appears.
+- Verify each new generator with the common exercise and transport invariants.
+
+## Exercise History
+
+A future exact-attempt record should store the resolved, versioned
+`PracticeExercise` used by the transport. Regenerating it from
+`ExerciseConfiguration` is insufficient because voicings, fingering,
+permutations, and generator behavior may change.
+
+Current `ExerciseHistoryEntry` stores only `ExerciseConfiguration`, so this
+internal refactor does not require a database migration. Exact exercise
+snapshots are a separate future history enhancement.
+
+## Testing Requirements
+
+### Domain Tests
+
+- Validate note pitch, hand, finger, equality, and JSON.
+- Validate non-empty steps, unique in-step pitches, deterministic serialization,
+  immutability, and structural identity.
+- Verify every existing strategy preserves its current musical output.
+
+### Application Tests
+
+- Verify exact pitch-set equality for singleton and multi-note steps.
+- Verify unexpected held pitches prevent advancement for singleton,
+  hands-together, and chord-sized steps.
+- Verify guidance and evaluation never read hand or finger from raw metadata.
+- Verify exercise completion and reset behavior remain unchanged.
+
+### Widget Tests
+
+- Verify every current-step pitch is highlighted.
+- Verify each displayed pitch receives hand, finger, spelling, and accessible
+  guidance from its `PracticeNote`.
+- Verify mixed and unequal-density hand patterns render without positional
+  metadata reconstruction.
+
+## Acceptance Criteria
+
+- [ ] `PracticeExercise` remains the canonical immutable exercise consumed by
+  `PracticeSession`.
+- [ ] `PracticeStep.notes` contains complete `PracticeNote` values.
+- [ ] No runtime consumer zips pitch, hand, or finger arrays from metadata.
+- [ ] `PracticeStrategy.initializeExercise()` continues returning
+  `PracticeExercise`.
+- [ ] `StepType` and its type-based evaluation branches are removed.
+- [ ] Every step uses one exact pitch-set evaluation rule.
+- [ ] Existing exercises preserve their step order, pitches, hands, fingers,
+  labels, and configuration metadata.
+- [ ] New generators can express single-hand, hands-together,
+  hands-independent, single-tone, multi-tone, mixed-texture, and bounded
+  permutation exercises without transport changes.
+
+## Future Semantics
+
+Duration, release, pedal, velocity, tempo, meter, accepted alternatives,
+bounded improvisation, and polyrhythm are outside V1. Future support must extend
+the exercise, step, or note contracts explicitly while preserving the hierarchy
+of ordered steps containing simultaneous note targets.

--- a/lib/application/state/practice_session.dart
+++ b/lib/application/state/practice_session.dart
@@ -427,19 +427,15 @@ class PracticeSession {
     }
 
     final currentStep = _currentExercise!.steps[_currentStepIndex];
-    // Defensive copy: some strategies reuse/mutate an internal notes buffer
-    // across steps, so callers must not receive a live reference to it.
-    onHighlightedNotesChanged(List<int>.from(currentStep.notes));
+    onHighlightedNotesChanged(List<int>.from(currentStep.midiNotes));
   }
 
   /// Handles MIDI note press events during practice sessions.
   ///
   /// Automatically starts the practice session on the first note if not already active.
   /// Processes incoming MIDI note data and advances the exercise if the
-  /// correct note is played. Behavior varies by step type:
-  /// - Sequential: Expects one note at a time
-  /// - Paired: Expects both notes to be held simultaneously
-  /// - Simultaneous: Expects all chord notes to be held together
+  /// correct set of notes is held. Every [PracticeStep] is one simultaneous
+  /// onset moment, whether it contains a singleton note or a larger sonority.
   ///
   /// The [midiNote] parameter should be the MIDI note number (0-127).
   void handleNotePressed(int midiNote) {
@@ -453,38 +449,10 @@ class PracticeSession {
       return;
     }
 
-    final currentStep = _currentExercise!.steps[_currentStepIndex];
-
-    switch (currentStep.type) {
-      case StepType.sequential:
-        // Expect one note at a time
-        if (currentStep.notes.length == 1 && midiNote == currentStep.notes[0]) {
-          _advanceToNextStep();
-        }
-        break;
-
-      case StepType.paired:
-        // Expect both notes of the pair to be held simultaneously
-        if (currentStep.notes.contains(midiNote)) {
-          _currentlyHeldNotes.add(midiNote);
-
-          // Check if all notes in the pair are now held
-          if (currentStep.notes.every(
-            (note) => _currentlyHeldNotes.contains(note),
-          )) {
-            _currentlyHeldNotes.clear();
-            _advanceToNextStep();
-          }
-        }
-        break;
-
-      case StepType.simultaneous:
-        // Track all held notes (including wrong ones) so set equality
-        // in _checkChordCompletion enforces "no extras"
-        _currentlyHeldNotes.add(midiNote);
-        _checkChordCompletion();
-        break;
-    }
+    // Track expected and unexpected notes so exact set equality enforces
+    // "no extras" for every step size.
+    _currentlyHeldNotes.add(midiNote);
+    _checkStepCompletion();
   }
 
   /// Advances to the next step in the exercise.
@@ -507,20 +475,20 @@ class PracticeSession {
   void handleNoteReleased(int midiNote) {
     if (_practiceActive) {
       _currentlyHeldNotes.remove(midiNote);
+      _checkStepCompletion();
     }
   }
 
-  void _checkChordCompletion() {
+  void _checkStepCompletion() {
     if (_currentExercise == null ||
         _currentStepIndex >= _currentExercise!.steps.length) {
       return;
     }
 
     final currentStep = _currentExercise!.steps[_currentStepIndex];
-    final expectedNotes = currentStep.notes.toSet();
 
     // Require exactly the expected notes to be held (no extras)
-    if (setEquals(_currentlyHeldNotes, expectedNotes)) {
+    if (setEquals(_currentlyHeldNotes, currentStep.expectedMidiNotes)) {
       _currentlyHeldNotes.clear();
       _advanceToNextStep();
     }

--- a/lib/domain/models/practice/exercise.dart
+++ b/lib/domain/models/practice/exercise.dart
@@ -1,120 +1,132 @@
 import "package:collection/collection.dart";
 import "package:meta/meta.dart";
 import "package:piano_fitness/domain/models/music/midi_note.dart";
+import "package:piano_fitness/domain/models/practice/practice_note.dart";
 
-/// The type of input expected for a practice step.
+export "package:piano_fitness/domain/models/practice/practice_note.dart";
+
+/// One onset moment in a practice exercise.
 ///
-/// Determines how notes should be played and validated during practice.
-enum StepType {
-  /// All notes in the step must be played simultaneously (e.g., chords).
-  simultaneous,
-
-  /// Notes in the step are played one at a time in sequence (e.g., single-hand scales).
-  sequential,
-
-  /// Notes form pairs that should be played together (e.g., both-hands scales/arpeggios).
-  /// Each pair of notes should be played simultaneously, then the next pair, etc.
-  paired,
-}
-
-/// A single step in a practice exercise.
-///
-/// Represents one or more notes to be played, along with metadata
-/// about how they should be played and what they represent.
+/// Every [notes] value is intended to begin together. Sequential material is
+/// represented by multiple ordered [PracticeStep] values.
 @immutable
 class PracticeStep {
-  /// Creates a practice step.
-  ///
-  /// The [notes] list contains MIDI note numbers (0-127) that should be
-  /// played in this step. How they are played depends on [type]:
-  /// - [StepType.simultaneous]: All notes played together (chord)
-  /// - [StepType.sequential]: Each note played one after another
-  /// - [StepType.paired]: Notes are paired (e.g., [left1, right1, left2, right2])
-  const PracticeStep({required this.notes, required this.type, this.metadata});
+  /// Creates a practice step containing one or more complete note targets.
+  PracticeStep({
+    required List<PracticeNote> notes,
+    Map<String, dynamic>? metadata,
+  }) : notes = List.unmodifiable(_validateNotes(notes)),
+       metadata = metadata == null
+           ? null
+           : Map.unmodifiable(Map<String, dynamic>.from(metadata));
 
-  /// Creates a practice step from a JSON map.
+  /// Creates a practice step from JSON.
   factory PracticeStep.fromJson(Map<String, dynamic> json) {
     return PracticeStep(
-      notes: (json["notes"] as List<dynamic>).cast<int>(),
-      type: StepType.values.byName(json["type"] as String),
+      notes: (json["notes"] as List<dynamic>)
+          .map((note) => PracticeNote.fromJson(note as Map<String, dynamic>))
+          .toList(),
       metadata: json["metadata"] as Map<String, dynamic>?,
     );
   }
 
-  /// The MIDI note numbers to be played in this step.
-  final List<int> notes;
-
-  /// How the notes should be played (simultaneously, sequentially, or in pairs).
-  final StepType type;
-
-  /// Optional metadata about this step.
+  /// Complete note targets intended to begin together.
   ///
-  /// Can include information like:
-  /// - `chordName`: Name of the chord (e.g., "C Major")
-  /// - `scaleDegree`: Scale degree number (e.g., "1", "2", "3")
-  /// - `inversion`: Chord inversion (e.g., "root", "first", "second")
-  /// - `description`: Human-readable description
+  /// List order is deterministic for display and serialization but has no
+  /// performance meaning within the step.
+  final List<PracticeNote> notes;
+
+  /// Optional information about this onset moment as a whole.
   final Map<String, dynamic>? metadata;
 
-  /// Converts this step to a JSON map for serialization.
+  /// The exact MIDI pitch set expected for this step.
+  Set<int> get expectedMidiNotes =>
+      Set.unmodifiable(notes.map((note) => note.pitch.value));
+
+  /// MIDI pitches in deterministic note order.
+  List<int> get midiNotes =>
+      List.unmodifiable(notes.map((note) => note.pitch.value));
+
+  /// Converts this step to JSON.
   Map<String, dynamic> toJson() {
     return {
-      "notes": notes,
-      "type": type.name,
+      "notes": notes.map((note) => note.toJson()).toList(),
       if (metadata != null) "metadata": metadata,
     };
   }
 
   /// Creates a copy of this step with optional field replacements.
   PracticeStep copyWith({
-    List<int>? notes,
-    StepType? type,
+    List<PracticeNote>? notes,
     Map<String, dynamic>? metadata,
   }) {
     return PracticeStep(
       notes: notes ?? this.notes,
-      type: type ?? this.type,
       metadata: metadata ?? this.metadata,
     );
+  }
+
+  static List<PracticeNote> _validateNotes(List<PracticeNote> notes) {
+    if (notes.isEmpty) {
+      throw ArgumentError.value(notes, "notes", "must not be empty");
+    }
+
+    final pitches = <int>{};
+    final assignedFingers = <(PracticeHand, int)>{};
+    for (final note in notes) {
+      if (!pitches.add(note.pitch.value)) {
+        throw ArgumentError.value(
+          note.pitch.value,
+          "notes",
+          "must not contain duplicate MIDI pitches",
+        );
+      }
+      final fingerNumber = note.fingerNumber;
+      if (fingerNumber != null &&
+          !assignedFingers.add((note.hand, fingerNumber))) {
+        throw ArgumentError.value(
+          fingerNumber,
+          "notes",
+          "a hand cannot assign one finger to multiple notes in a step",
+        );
+      }
+    }
+    return notes;
   }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-
     return other is PracticeStep &&
-        const ListEquality<int>().equals(other.notes, notes) &&
-        other.type == type &&
-        const MapEquality<String, dynamic>().equals(other.metadata, metadata);
+        const ListEquality<PracticeNote>().equals(other.notes, notes) &&
+        const DeepCollectionEquality().equals(other.metadata, metadata);
   }
 
   @override
   int get hashCode => Object.hash(
-    const ListEquality<int>().hash(notes),
-    type,
-    const MapEquality<String, dynamic>().hash(metadata),
+    const ListEquality<PracticeNote>().hash(notes),
+    const DeepCollectionEquality().hash(metadata),
   );
 
   @override
   String toString() {
-    return "PracticeStep(notes: $notes, type: $type${metadata != null ? ", metadata: $metadata" : ""})";
+    return "PracticeStep(notes: $notes${metadata != null ? ", metadata: $metadata" : ""})";
   }
 }
 
-/// A complete practice exercise consisting of multiple steps.
-///
-/// This is the unified representation for all practice exercise types
-/// (scales, arpeggios, chords, chord progressions). Each exercise is
-/// a sequence of steps to be completed in order.
+/// A complete practice exercise consisting of ordered onset steps.
 @immutable
 class PracticeExercise {
   /// Creates a practice exercise.
-  ///
-  /// The [steps] list defines the sequence of notes to practice.
-  /// Optional [metadata] can store information about the exercise as a whole.
-  const PracticeExercise({required this.steps, this.metadata});
+  PracticeExercise({
+    required List<PracticeStep> steps,
+    Map<String, dynamic>? metadata,
+  }) : steps = List.unmodifiable(steps),
+       metadata = metadata == null
+           ? null
+           : Map.unmodifiable(Map<String, dynamic>.from(metadata));
 
-  /// Creates a practice exercise from a JSON map.
+  /// Creates a practice exercise from JSON.
   factory PracticeExercise.fromJson(Map<String, dynamic> json) {
     return PracticeExercise(
       steps: (json["steps"] as List<dynamic>)
@@ -124,17 +136,10 @@ class PracticeExercise {
     );
   }
 
-  /// The steps that make up this exercise, in order.
+  /// The exercise's onset steps in performance order.
   final List<PracticeStep> steps;
 
-  /// Optional metadata about the exercise as a whole.
-  ///
-  /// Can include information like:
-  /// - `exerciseType`: Type of exercise (e.g., "scale", "arpeggio", "chord progression")
-  /// - `key`: Musical key (e.g., "C", "D♭", "F#")
-  /// - `mode`: Scale mode or chord quality (e.g., "major", "minor", "dorian")
-  /// - `difficulty`: Difficulty level
-  /// - `description`: Human-readable description
+  /// Optional information about the exercise as a whole.
   final Map<String, dynamic>? metadata;
 
   /// Returns true if this exercise has no steps.
@@ -147,18 +152,13 @@ class PracticeExercise {
   int get length => steps.length;
 
   /// Returns all unique MIDI notes used in this exercise.
-  ///
-  /// This is useful for calculating the piano keyboard range needed
-  /// to display the exercise.
   Set<MidiNote> getAllNotes() {
-    final allNotes = <int>{};
-    for (final step in steps) {
-      allNotes.addAll(step.notes);
-    }
-    return allNotes.toList().toMidiNotes().toSet();
+    return Set.unmodifiable(
+      steps.expand((step) => step.notes).map((note) => note.pitch),
+    );
   }
 
-  /// Converts this exercise to a JSON map for serialization.
+  /// Converts this exercise to JSON.
   Map<String, dynamic> toJson() {
     return {
       "steps": steps.map((step) => step.toJson()).toList(),
@@ -180,16 +180,15 @@ class PracticeExercise {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-
     return other is PracticeExercise &&
         const ListEquality<PracticeStep>().equals(other.steps, steps) &&
-        const MapEquality<String, dynamic>().equals(other.metadata, metadata);
+        const DeepCollectionEquality().equals(other.metadata, metadata);
   }
 
   @override
   int get hashCode => Object.hash(
     const ListEquality<PracticeStep>().hash(steps),
-    const MapEquality<String, dynamic>().hash(metadata),
+    const DeepCollectionEquality().hash(metadata),
   );
 
   @override

--- a/lib/domain/models/practice/practice_note.dart
+++ b/lib/domain/models/practice/practice_note.dart
@@ -1,0 +1,133 @@
+import "package:collection/collection.dart";
+import "package:meta/meta.dart";
+import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/music/midi_note.dart";
+
+/// The physical hand intended to play a [PracticeNote].
+enum PracticeHand { left, right }
+
+/// A complete note target within a practice step.
+///
+/// MIDI input can evaluate [pitch], while [hand] and [fingerNumber] provide
+/// pedagogical guidance.
+@immutable
+class PracticeNote {
+  /// Creates a practice note target.
+  PracticeNote({
+    required this.pitch,
+    required this.hand,
+    int? fingerNumber,
+    Map<String, dynamic>? annotations,
+  }) : fingerNumber = _validateFingerNumber(fingerNumber),
+       annotations = annotations == null
+           ? null
+           : Map.unmodifiable(Map<String, dynamic>.from(annotations));
+
+  /// Creates a practice note from JSON.
+  factory PracticeNote.fromJson(Map<String, dynamic> json) {
+    return PracticeNote(
+      pitch: MidiNote(json["midiNote"] as int),
+      hand: PracticeHand.values.byName(json["hand"] as String),
+      fingerNumber: json["fingerNumber"] as int?,
+      annotations: json["annotations"] as Map<String, dynamic>?,
+    );
+  }
+
+  /// The MIDI pitch to play.
+  final MidiNote pitch;
+
+  /// The hand intended to play [pitch].
+  final PracticeHand hand;
+
+  /// Optional fingering guidance from 1 (thumb) through 5 (little finger).
+  final int? fingerNumber;
+
+  /// Optional note-specific guidance that does not affect MIDI evaluation.
+  final Map<String, dynamic>? annotations;
+
+  /// Converts this note to JSON.
+  Map<String, dynamic> toJson() {
+    return {
+      "midiNote": pitch.value,
+      "hand": hand.name,
+      if (fingerNumber != null) "fingerNumber": fingerNumber,
+      if (annotations != null) "annotations": annotations,
+    };
+  }
+
+  static int? _validateFingerNumber(int? fingerNumber) {
+    if (fingerNumber != null && (fingerNumber < 1 || fingerNumber > 5)) {
+      throw ArgumentError.value(
+        fingerNumber,
+        "fingerNumber",
+        "must be between 1 and 5",
+      );
+    }
+    return fingerNumber;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PracticeNote &&
+        other.pitch == pitch &&
+        other.hand == hand &&
+        other.fingerNumber == fingerNumber &&
+        const DeepCollectionEquality().equals(other.annotations, annotations);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    pitch,
+    hand,
+    fingerNumber,
+    const DeepCollectionEquality().hash(annotations),
+  );
+
+  @override
+  String toString() {
+    return "PracticeNote(pitch: $pitch, hand: $hand, fingerNumber: $fingerNumber)";
+  }
+}
+
+/// Converts hand-grouped MIDI pitches into complete practice notes.
+///
+/// For [HandSelection.both], [pitches] must contain the left-hand voicing
+/// followed by an equal-sized right-hand voicing. This matches the existing
+/// chord-generation contract. Scales and arpeggios construct their interleaved
+/// hand targets directly.
+extension HandGroupedMidiNotes on List<MidiNote> {
+  /// Creates practice notes with optional index-aligned [fingerNumbers].
+  List<PracticeNote> toPracticeNotes({
+    required HandSelection handSelection,
+    List<int>? fingerNumbers,
+  }) {
+    if (fingerNumbers != null && fingerNumbers.length != length) {
+      throw ArgumentError(
+        "fingerNumbers must contain one value per MIDI pitch",
+      );
+    }
+    if (handSelection == HandSelection.both && length.isOdd) {
+      throw ArgumentError(
+        "Both-hands grouped pitches must contain equally sized hand voicings",
+      );
+    }
+
+    final handBoundary = length ~/ 2;
+    return List<PracticeNote>.unmodifiable(
+      List.generate(length, (index) {
+        final hand = switch (handSelection) {
+          HandSelection.left => PracticeHand.left,
+          HandSelection.right => PracticeHand.right,
+          HandSelection.both =>
+            index < handBoundary ? PracticeHand.left : PracticeHand.right,
+        };
+        return PracticeNote(
+          pitch: this[index],
+          hand: hand,
+          fingerNumber: fingerNumbers?[index],
+        );
+      }),
+    );
+  }
+}

--- a/lib/domain/models/practice/strategies/arpeggios_strategy.dart
+++ b/lib/domain/models/practice/strategies/arpeggios_strategy.dart
@@ -1,4 +1,5 @@
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/music/midi_note.dart";
 import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/practice_strategy.dart";
 import "package:piano_fitness/domain/services/music_theory/arpeggios.dart";
@@ -78,13 +79,21 @@ class ArpeggiosStrategy implements PracticeStrategy {
         final position = (i ~/ 2) + 1;
         steps.add(
           PracticeStep(
-            notes: [sequence[i], sequence[i + 1]],
-            type: StepType.paired,
+            notes: [
+              PracticeNote(
+                pitch: MidiNote(sequence[i]),
+                hand: PracticeHand.left,
+                fingerNumber: leftFingers[i ~/ 2],
+              ),
+              PracticeNote(
+                pitch: MidiNote(sequence[i + 1]),
+                hand: PracticeHand.right,
+                fingerNumber: rightFingers[i ~/ 2],
+              ),
+            ],
             metadata: {
-              "hand": "both",
               "position": position,
               "displayName": "Note $position (Both Hands)",
-              "fingers": [leftFingers[i ~/ 2], rightFingers[i ~/ 2]],
             },
           ),
         );
@@ -101,13 +110,18 @@ class ArpeggiosStrategy implements PracticeStrategy {
             : "Right";
         steps.add(
           PracticeStep(
-            notes: [sequence[i]],
-            type: StepType.sequential,
+            notes: [
+              PracticeNote(
+                pitch: MidiNote(sequence[i]),
+                hand: handSelection == HandSelection.left
+                    ? PracticeHand.left
+                    : PracticeHand.right,
+                fingerNumber: fingers[i],
+              ),
+            ],
             metadata: {
-              "hand": handSelection == HandSelection.left ? "left" : "right",
               "position": position,
               "displayName": "Note $position ($handDisplay Hand)",
-              "fingers": [fingers[i]],
             },
           ),
         );

--- a/lib/domain/models/practice/strategies/chord_progressions_strategy.dart
+++ b/lib/domain/models/practice/strategies/chord_progressions_strategy.dart
@@ -1,6 +1,5 @@
 import "package:piano_fitness/domain/models/music/chord_progression_type.dart";
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
-import "package:piano_fitness/domain/models/music/midi_note.dart";
 import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/practice_strategy.dart";
 import "package:piano_fitness/domain/models/music/scale_types.dart" as music;
@@ -47,8 +46,7 @@ class ChordProgressionsStrategy implements PracticeStrategy {
 
       steps.add(
         PracticeStep(
-          notes: chordNotes.values,
-          type: StepType.simultaneous,
+          notes: chordNotes.toPracticeNotes(handSelection: handSelection),
           metadata: {
             "chordName": chord.name,
             "rootNote": chord.rootNote.name,
@@ -58,7 +56,6 @@ class ChordProgressionsStrategy implements PracticeStrategy {
             "romanNumeral": chordProgression.romanNumerals[i],
             "displayName":
                 "${chordProgression.romanNumerals[i]}: ${chord.name}",
-            "hand": handSelection.name,
           },
         ),
       );

--- a/lib/domain/models/practice/strategies/chords_by_key_strategy.dart
+++ b/lib/domain/models/practice/strategies/chords_by_key_strategy.dart
@@ -63,8 +63,10 @@ class ChordsByKeyStrategy implements PracticeStrategy {
 
       steps.add(
         PracticeStep(
-          notes: chordNotes.values,
-          type: StepType.simultaneous,
+          notes: chordNotes.toPracticeNotes(
+            handSelection: handSelection,
+            fingerNumbers: fingers,
+          ),
           metadata: {
             "chordName": chord.name,
             "rootNote": chord.rootNote.name,
@@ -72,8 +74,6 @@ class ChordsByKeyStrategy implements PracticeStrategy {
             "inversion": chord.inversion.name,
             "position": i + 1,
             "displayName": chord.name,
-            "hand": handSelection.name,
-            "fingers": ?fingers,
           },
         ),
       );

--- a/lib/domain/models/practice/strategies/chords_by_type_strategy.dart
+++ b/lib/domain/models/practice/strategies/chords_by_type_strategy.dart
@@ -57,8 +57,10 @@ class ChordsByTypeStrategy implements PracticeStrategy {
 
       steps.add(
         PracticeStep(
-          notes: chordNotes.values,
-          type: StepType.simultaneous,
+          notes: chordNotes.toPracticeNotes(
+            handSelection: handSelection,
+            fingerNumbers: fingers,
+          ),
           metadata: {
             "chordName": chord.name,
             "rootNote": chord.rootNote.name,
@@ -66,8 +68,6 @@ class ChordsByTypeStrategy implements PracticeStrategy {
             "inversion": chord.inversion.name,
             "position": i + 1,
             "displayName": chord.name,
-            "hand": handSelection.name,
-            "fingers": ?fingers,
           },
         ),
       );

--- a/lib/domain/models/practice/strategies/dominant_cadence_strategy.dart
+++ b/lib/domain/models/practice/strategies/dominant_cadence_strategy.dart
@@ -117,8 +117,7 @@ class DominantCadenceStrategy implements PracticeStrategy {
 
       steps.add(
         PracticeStep(
-          notes: vNotes.values,
-          type: StepType.simultaneous,
+          notes: vNotes.toPracticeNotes(handSelection: handSelection),
           metadata: {
             "chordName": vChord.name,
             "rootNote": vChord.rootNote.name,
@@ -126,7 +125,6 @@ class DominantCadenceStrategy implements PracticeStrategy {
             "inversion": vChord.inversion.name,
             "position": pairIndex * 2 + 1,
             "displayName": vChord.name,
-            "hand": handSelection.name,
             "stepRole": "dominant",
             "pairIndex": pairIndex,
           },
@@ -141,8 +139,7 @@ class DominantCadenceStrategy implements PracticeStrategy {
 
       steps.add(
         PracticeStep(
-          notes: iNotes.values,
-          type: StepType.simultaneous,
+          notes: iNotes.toPracticeNotes(handSelection: handSelection),
           metadata: {
             "chordName": iChord.name,
             "rootNote": iChord.rootNote.name,
@@ -150,7 +147,6 @@ class DominantCadenceStrategy implements PracticeStrategy {
             "inversion": iChord.inversion.name,
             "position": pairIndex * 2 + 2,
             "displayName": _iTargetDisplayName(pair.iInv, includeSeventhChords),
-            "hand": handSelection.name,
             "stepRole": "tonic",
             "pairIndex": pairIndex,
           },

--- a/lib/domain/models/practice/strategies/scales_strategy.dart
+++ b/lib/domain/models/practice/strategies/scales_strategy.dart
@@ -1,4 +1,5 @@
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/music/midi_note.dart";
 import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/practice_strategy.dart";
 import "package:piano_fitness/domain/services/music_theory/fingering_hints.dart";
@@ -71,13 +72,21 @@ class ScalesStrategy implements PracticeStrategy {
           final degree = (i ~/ 2) + 1;
           steps.add(
             PracticeStep(
-              notes: [sequence[i], sequence[i + 1]],
-              type: StepType.paired,
+              notes: [
+                PracticeNote(
+                  pitch: MidiNote(sequence[i]),
+                  hand: PracticeHand.left,
+                  fingerNumber: leftFingers[i ~/ 2],
+                ),
+                PracticeNote(
+                  pitch: MidiNote(sequence[i + 1]),
+                  hand: PracticeHand.right,
+                  fingerNumber: rightFingers[i ~/ 2],
+                ),
+              ],
               metadata: {
-                "hand": "both",
                 "degree": degree,
                 "displayName": "Degree $degree (Both Hands)",
-                "fingers": [leftFingers[i ~/ 2], rightFingers[i ~/ 2]],
               },
             ),
           );
@@ -95,13 +104,18 @@ class ScalesStrategy implements PracticeStrategy {
             : "Right";
         steps.add(
           PracticeStep(
-            notes: [sequence[i]],
-            type: StepType.sequential,
+            notes: [
+              PracticeNote(
+                pitch: MidiNote(sequence[i]),
+                hand: handSelection == HandSelection.left
+                    ? PracticeHand.left
+                    : PracticeHand.right,
+                fingerNumber: fingers[i],
+              ),
+            ],
             metadata: {
-              "hand": handSelection == HandSelection.left ? "left" : "right",
               "degree": degree,
               "displayName": "Degree $degree ($handDisplay Hand)",
-              "fingers": [fingers[i]],
             },
           ),
         );

--- a/lib/presentation/features/practice/practice_page.dart
+++ b/lib/presentation/features/practice/practice_page.dart
@@ -274,7 +274,7 @@ class _PracticePageViewState extends State<_PracticePageView> {
               highlightedNotes[i]: PianoKeyVisual(
                 fill: colorScheme.primary,
                 label: fingers != null && i < fingers.length
-                    ? fingers[i].toString()
+                    ? fingers[i]?.toString()
                     : null,
               ),
           });

--- a/lib/presentation/features/practice/practice_page_view_model.dart
+++ b/lib/presentation/features/practice/practice_page_view_model.dart
@@ -299,14 +299,16 @@ class PracticePageViewModel extends ChangeNotifier {
         : _midiState.activeNotes.toList();
   }
 
-  /// Finger numbers for the current step's notes, aligned index-for-index
-  /// with [getDisplayHighlightedNotes]'s active-step notes. Returns `null`
-  /// when there's no active step (so the display fell back to raw MIDI
-  /// input notes) or the step has no fingering metadata.
-  List<int>? get currentStepFingers {
+  /// Finger numbers for the current step's notes, aligned index-for-index with
+  /// [getDisplayHighlightedNotes]'s active-step notes. Returns `null` when
+  /// there is no active guided step or none of its notes has fingering.
+  List<int?>? get currentStepFingers {
     if (_highlightedNotes.isEmpty) return null;
-    final fingers = _practiceSession?.currentStep?.metadata?["fingers"];
-    return fingers is List ? fingers.cast<int>() : null;
+    final notes = _practiceSession?.currentStep?.notes;
+    if (notes == null || notes.every((note) => note.fingerNumber == null)) {
+      return null;
+    }
+    return notes.map((note) => note.fingerNumber).toList(growable: false);
   }
 
   /// Notes for piano range calculation, used by the view to compute display range.

--- a/lib/presentation/utils/practice_accessibility_utils.dart
+++ b/lib/presentation/utils/practice_accessibility_utils.dart
@@ -1,15 +1,14 @@
 import "package:piano_fitness/domain/models/practice/exercise.dart";
-import "package:piano_fitness/domain/services/music_theory/note_utils.dart";
 
 /// Utilities for generating accessibility semantics for practice exercises.
 ///
-/// Provides step-type-aware semantic labels and announcements to help
-/// screen reader users understand how to interact with practice exercises.
+/// Provides semantic labels and announcements to help screen reader users
+/// understand how to interact with practice exercises.
 class PracticeAccessibilityUtils {
-  /// Generates a step-type-aware semantic label for a practice step.
+  /// Generates a semantic label for a practice step.
   ///
   /// Returns a descriptive label that includes the step number, display name
-  /// (if available), and hints about how to play the step based on its type.
+  /// (if available), and a hint based on the number of simultaneous notes.
   ///
   /// Example outputs:
   /// - "Step 1 of 8: Degree 1 (Right Hand). Play this note"
@@ -22,15 +21,15 @@ class PracticeAccessibilityUtils {
   ) {
     final displayName =
         step.metadata?["displayName"] as String? ?? "Step $stepNumber";
-    final stepTypeHint = _getStepTypeHint(step.type);
+    final stepHint = _getStepHint(step.notes.length);
 
-    return "Step $stepNumber of $totalSteps: $displayName. $stepTypeHint";
+    return "Step $stepNumber of $totalSteps: $displayName. $stepHint";
   }
 
   /// Generates a semantic announcement when advancing to a new step.
   ///
   /// Returns an announcement that includes the step's display name,
-  /// an action hint based on step type, and the notes to be played.
+  /// an action hint based on step size, and the notes to be played.
   ///
   /// Example outputs:
   /// - "Degree 2 (Right Hand). Press: D4"
@@ -42,45 +41,30 @@ class PracticeAccessibilityUtils {
   ) {
     final displayName =
         newStep.metadata?["displayName"] as String? ?? "Step $stepNumber";
-    final actionHint = _getActionHint(newStep.type);
+    final actionHint = _getActionHint(newStep.notes.length);
     final noteNames = _formatNoteNames(newStep.notes);
 
     return "$displayName. $actionHint $noteNames";
   }
 
-  /// Returns a hint describing how to play a step based on its type.
-  static String _getStepTypeHint(StepType type) {
-    switch (type) {
-      case StepType.simultaneous:
-        return "Play all notes together simultaneously";
-      case StepType.sequential:
-        return "Play this note";
-      case StepType.paired:
-        return "Play both notes together";
-    }
+  /// Returns a hint describing how to play a simultaneous onset step.
+  static String _getStepHint(int noteCount) {
+    if (noteCount == 1) return "Play this note";
+    if (noteCount == 2) return "Play both notes together";
+    return "Play all notes together simultaneously";
   }
 
   /// Returns an action hint for announcing step changes.
-  static String _getActionHint(StepType type) {
-    switch (type) {
-      case StepType.simultaneous:
-        return "Press and hold together:";
-      case StepType.sequential:
-        return "Press:";
-      case StepType.paired:
-        return "Press both notes together:";
-    }
+  static String _getActionHint(int noteCount) {
+    if (noteCount == 1) return "Press:";
+    if (noteCount == 2) return "Press both notes together:";
+    return "Press and hold together:";
   }
 
-  /// Formats a list of MIDI note numbers into readable note names.
+  /// Formats a list of practice notes into readable note names.
   ///
   /// Returns a comma-separated list of note names (e.g., "C4, E4, G4").
-  static String _formatNoteNames(List<int> midiNotes) {
-    return midiNotes
-        .map((midi) {
-          final noteInfo = NoteUtils.midiNumberToNote(midi);
-          return NoteUtils.noteDisplayName(noteInfo.note, noteInfo.octave);
-        })
-        .join(", ");
+  static String _formatNoteNames(List<PracticeNote> notes) {
+    return notes.map((note) => note.pitch.displayName).join(", ");
   }
 }

--- a/test/application/state/practice_session_test.dart
+++ b/test/application/state/practice_session_test.dart
@@ -6,6 +6,7 @@
 import "package:flutter_test/flutter_test.dart";
 
 import "package:piano_fitness/domain/models/practice/practice_mode.dart";
+import "package:piano_fitness/domain/models/music/hand_selection.dart";
 import "package:piano_fitness/application/state/practice_session.dart";
 import "package:piano_fitness/domain/services/music_theory/arpeggios.dart";
 import "package:piano_fitness/domain/services/music_theory/circle_of_fifths.dart";
@@ -401,6 +402,55 @@ void main() {
 
         // Highlights should be different (different key)
         expect(highlightsAfter, isNot(equals(highlightsBefore)));
+      });
+    });
+
+    group("Unified step evaluation", () {
+      test("unexpected held pitch blocks a singleton step", () {
+        practiceSession.setPracticeMode(PracticeMode.scales);
+        practiceSession.setSelectedHandSelection(HandSelection.right);
+        final expectedNote = practiceSession.currentStep!.midiNotes.single;
+
+        practiceSession.handleNotePressed(1);
+        practiceSession.handleNotePressed(expectedNote);
+
+        expect(practiceSession.currentStepIndex, 0);
+
+        practiceSession.handleNoteReleased(1);
+
+        expect(practiceSession.currentStepIndex, 1);
+      });
+
+      test("hands-together step advances on exact pitch-set equality", () {
+        practiceSession.setPracticeMode(PracticeMode.scales);
+        final expectedNotes = practiceSession.currentStep!.midiNotes;
+        expect(expectedNotes, hasLength(2));
+
+        practiceSession.handleNotePressed(1);
+        practiceSession.handleNotePressed(expectedNotes.first);
+        expect(practiceSession.currentStepIndex, 0);
+
+        practiceSession.handleNotePressed(expectedNotes.last);
+        expect(practiceSession.currentStepIndex, 0);
+
+        practiceSession.handleNoteReleased(1);
+        expect(practiceSession.currentStepIndex, 1);
+      });
+
+      test("blocked chord uses the same exact pitch-set rule", () {
+        practiceSession.setPracticeMode(PracticeMode.chordsByKey);
+        final expectedNotes = practiceSession.currentStep!.midiNotes;
+        expect(expectedNotes.length, greaterThan(2));
+
+        practiceSession.handleNotePressed(1);
+        for (final note in expectedNotes) {
+          practiceSession.handleNotePressed(note);
+        }
+
+        expect(practiceSession.currentStepIndex, 0);
+
+        practiceSession.handleNoteReleased(1);
+        expect(practiceSession.currentStepIndex, 1);
       });
     });
   });

--- a/test/domain/models/practice/exercise_test.dart
+++ b/test/domain/models/practice/exercise_test.dart
@@ -1,0 +1,196 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/music/midi_note.dart";
+import "package:piano_fitness/domain/models/practice/exercise.dart";
+
+PracticeNote _note(
+  int midiNote, {
+  PracticeHand hand = PracticeHand.right,
+  int? fingerNumber,
+}) {
+  return PracticeNote(
+    pitch: MidiNote(midiNote),
+    hand: hand,
+    fingerNumber: fingerNumber,
+  );
+}
+
+void main() {
+  group("PracticeNote", () {
+    test("round-trips complete guidance through JSON", () {
+      final note = PracticeNote(
+        pitch: MidiNote(61),
+        hand: PracticeHand.left,
+        fingerNumber: 2,
+        annotations: {"spelling": "D-flat", "degree": 2},
+      );
+
+      expect(PracticeNote.fromJson(note.toJson()), note);
+      expect(note.toJson(), {
+        "midiNote": 61,
+        "hand": "left",
+        "fingerNumber": 2,
+        "annotations": {"spelling": "D-flat", "degree": 2},
+      });
+    });
+
+    test("validates optional finger number", () {
+      expect(() => _note(60, fingerNumber: 0), throwsArgumentError);
+      expect(() => _note(60, fingerNumber: 6), throwsArgumentError);
+      expect(_note(60).fingerNumber, isNull);
+    });
+
+    test("makes annotations read-only", () {
+      final note = PracticeNote(
+        pitch: MidiNote(60),
+        hand: PracticeHand.right,
+        annotations: {"degree": 1},
+      );
+
+      expect(() => note.annotations!["degree"] = 2, throwsUnsupportedError);
+    });
+  });
+
+  group("HandGroupedMidiNotes", () {
+    test("assigns one hand to a single-hand voicing", () {
+      final notes = [MidiNote(60), MidiNote(64), MidiNote(67)].toPracticeNotes(
+        handSelection: HandSelection.right,
+        fingerNumbers: [1, 3, 5],
+      );
+
+      expect(notes.map((note) => note.hand), everyElement(PracticeHand.right));
+      expect(notes.map((note) => note.fingerNumber), [1, 3, 5]);
+    });
+
+    test("splits grouped both-hand voicings at the midpoint", () {
+      final notes =
+          [
+            MidiNote(48),
+            MidiNote(52),
+            MidiNote(55),
+            MidiNote(60),
+            MidiNote(64),
+            MidiNote(67),
+          ].toPracticeNotes(
+            handSelection: HandSelection.both,
+            fingerNumbers: [5, 3, 1, 1, 3, 5],
+          );
+
+      expect(notes.map((note) => note.hand), [
+        PracticeHand.left,
+        PracticeHand.left,
+        PracticeHand.left,
+        PracticeHand.right,
+        PracticeHand.right,
+        PracticeHand.right,
+      ]);
+    });
+
+    test("rejects mismatched fingers and uneven both-hand groups", () {
+      expect(
+        () => [MidiNote(60)].toPracticeNotes(
+          handSelection: HandSelection.right,
+          fingerNumbers: [1, 2],
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => [
+          MidiNote(48),
+          MidiNote(52),
+          MidiNote(60),
+        ].toPracticeNotes(handSelection: HandSelection.both),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group("PracticeStep", () {
+    test("derives deterministic and set-shaped MIDI views", () {
+      final step = PracticeStep(
+        notes: [
+          _note(60, fingerNumber: 1),
+          _note(64, fingerNumber: 3),
+          _note(67, fingerNumber: 5),
+        ],
+        metadata: {"displayName": "C major"},
+      );
+
+      expect(step.midiNotes, [60, 64, 67]);
+      expect(step.expectedMidiNotes, {60, 64, 67});
+    });
+
+    test("rejects empty steps and duplicate MIDI pitches", () {
+      expect(() => PracticeStep(notes: []), throwsArgumentError);
+      expect(
+        () => PracticeStep(
+          notes: [
+            _note(60, hand: PracticeHand.left),
+            _note(60),
+          ],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test("rejects one hand assigning a finger twice", () {
+      expect(
+        () => PracticeStep(
+          notes: [_note(60, fingerNumber: 1), _note(64, fingerNumber: 1)],
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        PracticeStep(
+          notes: [
+            _note(48, hand: PracticeHand.left, fingerNumber: 1),
+            _note(60, fingerNumber: 1),
+          ],
+        ),
+        isA<PracticeStep>(),
+      );
+    });
+
+    test("round-trips without StepType or note-level metadata arrays", () {
+      final step = PracticeStep(
+        notes: [
+          _note(48, hand: PracticeHand.left, fingerNumber: 5),
+          _note(60, fingerNumber: 1),
+        ],
+        metadata: {"displayName": "Hands together"},
+      );
+      final json = step.toJson();
+
+      expect(PracticeStep.fromJson(json), step);
+      expect(json, isNot(contains("type")));
+      expect(json["metadata"], isNot(contains("hand")));
+      expect(json["metadata"], isNot(contains("fingers")));
+    });
+
+    test("makes note and metadata collections read-only", () {
+      final step = PracticeStep(
+        notes: [_note(60)],
+        metadata: {"displayName": "C"},
+      );
+
+      expect(() => step.notes.add(_note(62)), throwsUnsupportedError);
+      expect(() => step.metadata!["displayName"] = "D", throwsUnsupportedError);
+    });
+  });
+
+  group("PracticeExercise", () {
+    test("collects unique pitches and round-trips through JSON", () {
+      final exercise = PracticeExercise(
+        steps: [
+          PracticeStep(notes: [_note(60)]),
+          PracticeStep(notes: [_note(60), _note(64)]),
+        ],
+        metadata: {"exerciseType": "test"},
+      );
+
+      expect(exercise.getAllNotes().map((note) => note.value), {60, 64});
+      expect(PracticeExercise.fromJson(exercise.toJson()), exercise);
+    });
+  });
+}

--- a/test/domain/models/practice/strategies/arpeggios_strategy_test.dart
+++ b/test/domain/models/practice/strategies/arpeggios_strategy_test.dart
@@ -1,5 +1,6 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/arpeggios_strategy.dart";
 import "package:piano_fitness/domain/services/music_theory/arpeggios.dart";
 import "package:piano_fitness/domain/services/music_theory/note_utils.dart";
@@ -22,6 +23,15 @@ void main() {
       expect(exercise.metadata?["rootNote"], "c");
       expect(exercise.metadata?["arpeggioType"], "major");
       expect(exercise.metadata?["handSelection"], "both");
+      expect(exercise.steps.first.midiNotes, [48, 60]);
+      expect(exercise.steps.first.notes.map((note) => note.hand), [
+        PracticeHand.left,
+        PracticeHand.right,
+      ]);
+      expect(exercise.steps.first.notes.map((note) => note.fingerNumber), [
+        5,
+        1,
+      ]);
     });
 
     test("should initialize D minor arpeggio sequence for left hand", () {
@@ -40,6 +50,10 @@ void main() {
       expect(exercise.metadata?["rootNote"], "d");
       expect(exercise.metadata?["arpeggioType"], "minor");
       expect(exercise.metadata?["handSelection"], "left");
+      expect(
+        exercise.steps.expand((step) => step.notes).map((note) => note.hand),
+        everyElement(PracticeHand.left),
+      );
     });
 
     test("should initialize two-octave arpeggio sequence", () {

--- a/test/domain/models/practice/strategies/chord_progressions_strategy_test.dart
+++ b/test/domain/models/practice/strategies/chord_progressions_strategy_test.dart
@@ -1,6 +1,7 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:piano_fitness/domain/models/music/chord_progression_type.dart";
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/chord_progressions_strategy.dart";
 import "package:piano_fitness/domain/services/music_theory/scales.dart"
     as music;
@@ -136,7 +137,11 @@ void main() {
       // Left hand plays one octave lower: C3, E3, G3
       final firstStep = exercise.steps.first;
       expect(firstStep.notes.length, 3);
-      expect(firstStep.notes, containsAll([48, 52, 55])); // C3, E3, G3
+      expect(firstStep.midiNotes, [48, 52, 55]); // C3, E3, G3
+      expect(
+        firstStep.notes.map((note) => note.hand),
+        everyElement(PracticeHand.left),
+      );
     });
 
     test("should handle right hand selection correctly", () {
@@ -159,7 +164,11 @@ void main() {
       // Verify first chord (C major) has full triad (3 notes) in right hand octave
       final firstStep = exercise.steps.first;
       expect(firstStep.notes.length, 3);
-      expect(firstStep.notes, containsAll([60, 64, 67])); // C4, E4, G4
+      expect(firstStep.midiNotes, [60, 64, 67]); // C4, E4, G4
+      expect(
+        firstStep.notes.map((note) => note.hand),
+        everyElement(PracticeHand.right),
+      );
     });
 
     test("should handle both hands selection correctly", () {
@@ -184,7 +193,17 @@ void main() {
       expect(firstStep.notes.length, 6);
       // Left hand one octave lower: [48, 52, 55] = [C3, E3, G3]
       // Right hand at specified octave: [60, 64, 67] = [C4, E4, G4]
-      expect(firstStep.notes, containsAll([48, 52, 55, 60, 64, 67]));
+      expect(firstStep.midiNotes, [48, 52, 55, 60, 64, 67]);
+      expect(firstStep.notes.take(3).map((note) => note.hand), [
+        PracticeHand.left,
+        PracticeHand.left,
+        PracticeHand.left,
+      ]);
+      expect(firstStep.notes.skip(3).map((note) => note.hand), [
+        PracticeHand.right,
+        PracticeHand.right,
+        PracticeHand.right,
+      ]);
     });
   });
 }

--- a/test/domain/models/practice/strategies/chords_by_key_strategy_test.dart
+++ b/test/domain/models/practice/strategies/chords_by_key_strategy_test.dart
@@ -1,5 +1,6 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/chords_by_key_strategy.dart";
 import "package:piano_fitness/domain/services/music_theory/scales.dart"
     as music;
@@ -87,7 +88,11 @@ void main() {
       // Left hand plays one octave lower: C3, E3, G3
       final firstStep = exercise.steps.first;
       expect(firstStep.notes.length, 3);
-      expect(firstStep.notes, containsAll([48, 52, 55])); // C3, E3, G3
+      expect(firstStep.midiNotes, [48, 52, 55]); // C3, E3, G3
+      expect(
+        firstStep.notes.map((note) => note.hand),
+        everyElement(PracticeHand.left),
+      );
     });
 
     test("should handle right hand selection correctly", () {
@@ -107,7 +112,11 @@ void main() {
       // Verify first chord (C major) has full triad (3 notes) in right hand octave
       final firstStep = exercise.steps.first;
       expect(firstStep.notes.length, 3);
-      expect(firstStep.notes, containsAll([60, 64, 67])); // C4, E4, G4
+      expect(firstStep.midiNotes, [60, 64, 67]); // C4, E4, G4
+      expect(
+        firstStep.notes.map((note) => note.hand),
+        everyElement(PracticeHand.right),
+      );
     });
 
     test("should handle both hands selection correctly", () {
@@ -129,7 +138,25 @@ void main() {
       expect(firstStep.notes.length, 6);
       // Left hand one octave lower: [48, 52, 55] = [C3, E3, G3]
       // Right hand at specified octave: [60, 64, 67] = [C4, E4, G4]
-      expect(firstStep.notes, containsAll([48, 52, 55, 60, 64, 67]));
+      expect(firstStep.midiNotes, [48, 52, 55, 60, 64, 67]);
+      expect(firstStep.notes.take(3).map((note) => note.hand), [
+        PracticeHand.left,
+        PracticeHand.left,
+        PracticeHand.left,
+      ]);
+      expect(firstStep.notes.skip(3).map((note) => note.hand), [
+        PracticeHand.right,
+        PracticeHand.right,
+        PracticeHand.right,
+      ]);
+      expect(firstStep.notes.map((note) => note.fingerNumber), [
+        5,
+        3,
+        1,
+        1,
+        3,
+        5,
+      ]);
     });
   });
 }

--- a/test/domain/models/practice/strategies/chords_by_type_strategy_test.dart
+++ b/test/domain/models/practice/strategies/chords_by_type_strategy_test.dart
@@ -1,5 +1,6 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/chords_by_type_strategy.dart";
 import "package:piano_fitness/domain/services/music_theory/chords.dart";
 
@@ -92,7 +93,11 @@ void main() {
       // Left hand plays one octave lower: C3, E3, G3
       final firstStep = exercise.steps.first;
       expect(firstStep.notes.length, 3);
-      expect(firstStep.notes, containsAll([48, 52, 55])); // C3, E3, G3
+      expect(firstStep.midiNotes, [48, 52, 55]); // C3, E3, G3
+      expect(
+        firstStep.notes.map((note) => note.hand),
+        everyElement(PracticeHand.left),
+      );
     });
 
     test("should handle right hand selection correctly", () {
@@ -111,7 +116,11 @@ void main() {
       // Verify first chord (C major) has full triad (3 notes) in right hand octave
       final firstStep = exercise.steps.first;
       expect(firstStep.notes.length, 3);
-      expect(firstStep.notes, containsAll([60, 64, 67])); // C4, E4, G4
+      expect(firstStep.midiNotes, [60, 64, 67]); // C4, E4, G4
+      expect(
+        firstStep.notes.map((note) => note.hand),
+        everyElement(PracticeHand.right),
+      );
     });
 
     test("should handle both hands selection correctly", () {
@@ -132,7 +141,25 @@ void main() {
       expect(firstStep.notes.length, 6);
       // Left hand one octave lower: [48, 52, 55] = [C3, E3, G3]
       // Right hand at specified octave: [60, 64, 67] = [C4, E4, G4]
-      expect(firstStep.notes, containsAll([48, 52, 55, 60, 64, 67]));
+      expect(firstStep.midiNotes, [48, 52, 55, 60, 64, 67]);
+      expect(firstStep.notes.take(3).map((note) => note.hand), [
+        PracticeHand.left,
+        PracticeHand.left,
+        PracticeHand.left,
+      ]);
+      expect(firstStep.notes.skip(3).map((note) => note.hand), [
+        PracticeHand.right,
+        PracticeHand.right,
+        PracticeHand.right,
+      ]);
+      expect(firstStep.notes.map((note) => note.fingerNumber), [
+        5,
+        3,
+        1,
+        1,
+        3,
+        5,
+      ]);
     });
   });
 }

--- a/test/domain/models/practice/strategies/dominant_cadence_strategy_test.dart
+++ b/test/domain/models/practice/strategies/dominant_cadence_strategy_test.dart
@@ -2,7 +2,6 @@ import "dart:math" show min;
 
 import "package:flutter_test/flutter_test.dart";
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
-import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/dominant_cadence_strategy.dart";
 import "package:piano_fitness/domain/services/music_theory/scales.dart"
     as music;
@@ -87,10 +86,11 @@ void main() {
         expect(exercise.steps.length, equals(6));
       });
 
-      test("all steps are simultaneous type", () {
+      test("all steps contain one simultaneous chord onset", () {
         final exercise = strategy.initializeExercise();
         for (final step in exercise.steps) {
-          expect(step.type, equals(StepType.simultaneous));
+          expect(step.notes, hasLength(3));
+          expect(step.expectedMidiNotes, hasLength(3));
         }
       });
 
@@ -148,8 +148,8 @@ void main() {
       // Voice leading: B4→C5 (+1 leading tone), D5→E5 (+2 step), G5→G5 (hold)
       test("pair 1 MIDI notes are correct for C major right hand", () {
         final exercise = strategy.initializeExercise();
-        expect(exercise.steps[0].notes, equals([71, 74, 79])); // V 1st inv
-        expect(exercise.steps[1].notes, equals([72, 76, 79])); // I Root
+        expect(exercise.steps[0].midiNotes, equals([71, 74, 79]));
+        expect(exercise.steps[1].midiNotes, equals([72, 76, 79]));
       });
 
       test("generates different MIDI sequences for different keys", () {
@@ -214,8 +214,8 @@ void main() {
           final exercise = s.initializeExercise();
           for (var i = 0; i < exercise.steps.length; i += 2) {
             _checkVoiceLeading(
-              exercise.steps[i].notes,
-              exercise.steps[i + 1].notes,
+              exercise.steps[i].midiNotes,
+              exercise.steps[i + 1].midiNotes,
               reason: "Key ${key.displayName} pair ${i ~/ 2 + 1}",
             );
           }
@@ -244,10 +244,11 @@ void main() {
         expect(exercise.steps.length, equals(8));
       });
 
-      test("all steps are simultaneous type", () {
+      test("all steps contain one simultaneous seventh-chord onset", () {
         final exercise = strategy.initializeExercise();
         for (final step in exercise.steps) {
-          expect(step.type, equals(StepType.simultaneous));
+          expect(step.notes, hasLength(4));
+          expect(step.expectedMidiNotes, hasLength(4));
         }
       });
 
@@ -300,8 +301,8 @@ void main() {
       //         iOctaveOffset=0: keeping I at startOctave preserves common tones.
       test("pair 1 MIDI notes are correct for C major right hand", () {
         final exercise = strategy.initializeExercise();
-        expect(exercise.steps[0].notes, equals([67, 71, 74, 77]));
-        expect(exercise.steps[1].notes, equals([60, 64, 67, 71]));
+        expect(exercise.steps[0].midiNotes, equals([67, 71, 74, 77]));
+        expect(exercise.steps[1].midiNotes, equals([60, 64, 67, 71]));
       });
 
       // Pair 4: V7 3rd inv (G root=G4=67, 3rd inv bass=F above root) = F5(77), G5(79), B5(83), D6(86)
@@ -310,8 +311,8 @@ void main() {
       //         Note: Higher octave chosen by voice leading algorithm to minimize jumps
       test("pair 4 MIDI notes are correct for C major right hand", () {
         final exercise = strategy.initializeExercise();
-        expect(exercise.steps[6].notes, equals([77, 79, 83, 86]));
-        expect(exercise.steps[7].notes, equals([83, 84, 88, 91]));
+        expect(exercise.steps[6].midiNotes, equals([77, 79, 83, 86]));
+        expect(exercise.steps[7].midiNotes, equals([83, 84, 88, 91]));
       });
 
       test("initialises successfully for all 12 keys", () {
@@ -343,8 +344,8 @@ void main() {
 
           // Test all 4 pairs (8 steps total, pairs at indices 0-1, 2-3, 4-5, 6-7)
           for (var i = 0; i < exercise.steps.length; i += 2) {
-            final vNotes = exercise.steps[i].notes;
-            final iNotes = exercise.steps[i + 1].notes;
+            final vNotes = exercise.steps[i].midiNotes;
+            final iNotes = exercise.steps[i + 1].midiNotes;
 
             // For seventh chords with auto-bump logic, allow common tones to move
             // by up to an octave when necessary, and allow larger non-common movements

--- a/test/domain/models/practice/strategies/scales_strategy_test.dart
+++ b/test/domain/models/practice/strategies/scales_strategy_test.dart
@@ -113,12 +113,12 @@ void main() {
 
       for (var i = 0; i < exercise.steps.length; i++) {
         expect(
-          exercise.steps[i].notes,
+          exercise.steps[i].midiNotes,
           equals([expectedNotes[i]]),
           reason: "Step $i should contain MIDI note ${expectedNotes[i]}",
         );
-        expect(exercise.steps[i].type, equals(StepType.sequential));
-        expect(exercise.steps[i].metadata?["hand"], equals("right"));
+        expect(exercise.steps[i].notes.single.hand, PracticeHand.right);
+        expect(exercise.steps[i].notes.single.fingerNumber, isNotNull);
       }
     });
 
@@ -159,12 +159,12 @@ void main() {
 
         for (var i = 0; i < exercise.steps.length; i++) {
           expect(
-            exercise.steps[i].notes,
+            exercise.steps[i].midiNotes,
             equals([expectedNotes[i]]),
             reason: "Step $i should contain MIDI note ${expectedNotes[i]}",
           );
-          expect(exercise.steps[i].type, equals(StepType.sequential));
-          expect(exercise.steps[i].metadata?["hand"], equals("left"));
+          expect(exercise.steps[i].notes.single.hand, PracticeHand.left);
+          expect(exercise.steps[i].notes.single.fingerNumber, isNotNull);
         }
       },
     );
@@ -205,12 +205,18 @@ void main() {
 
         for (var i = 0; i < exercise.steps.length; i++) {
           expect(
-            exercise.steps[i].notes,
+            exercise.steps[i].midiNotes,
             equals(expectedPairs[i]),
             reason: "Step $i should contain paired notes ${expectedPairs[i]}",
           );
-          expect(exercise.steps[i].type, equals(StepType.paired));
-          expect(exercise.steps[i].metadata?["hand"], equals("both"));
+          expect(exercise.steps[i].notes.map((note) => note.hand), [
+            PracticeHand.left,
+            PracticeHand.right,
+          ]);
+          expect(
+            exercise.steps[i].notes.map((note) => note.fingerNumber),
+            everyElement(isNotNull),
+          );
         }
       },
     );
@@ -249,7 +255,7 @@ void main() {
 
       for (var i = 0; i < exercise.steps.length; i++) {
         expect(
-          exercise.steps[i].notes,
+          exercise.steps[i].midiNotes,
           equals([expectedNotes[i]]),
           reason: "Step $i should contain MIDI note ${expectedNotes[i]}",
         );
@@ -292,7 +298,7 @@ void main() {
 
         for (var i = 0; i < exercise.steps.length; i++) {
           expect(
-            exercise.steps[i].notes,
+            exercise.steps[i].midiNotes,
             equals([expectedNotes[i]]),
             reason: "Step $i should contain MIDI note ${expectedNotes[i]}",
           );

--- a/test/presentation/widgets/practice_progress_display_theme_test.dart
+++ b/test/presentation/widgets/practice_progress_display_theme_test.dart
@@ -1,8 +1,12 @@
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:piano_fitness/domain/models/music/midi_note.dart";
 import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/practice_mode.dart";
 import "package:piano_fitness/presentation/widgets/practice_progress_display.dart";
+
+PracticeNote _note(int midiNote) =>
+    PracticeNote(pitch: MidiNote(midiNote), hand: PracticeHand.right);
 
 void main() {
   group("PracticeProgressDisplay Theme Tests", () {
@@ -11,43 +15,35 @@ void main() {
       final testExercise = PracticeExercise(
         steps: [
           PracticeStep(
-            notes: [60],
-            type: StepType.sequential,
+            notes: [_note(60)],
             metadata: {"displayName": "Degree 1 (Right Hand)"},
           ),
           PracticeStep(
-            notes: [62],
-            type: StepType.sequential,
+            notes: [_note(62)],
             metadata: {"displayName": "Degree 2 (Right Hand)"},
           ),
           PracticeStep(
-            notes: [64],
-            type: StepType.sequential,
+            notes: [_note(64)],
             metadata: {"displayName": "Degree 3 (Right Hand)"},
           ),
           PracticeStep(
-            notes: [65],
-            type: StepType.sequential,
+            notes: [_note(65)],
             metadata: {"displayName": "Degree 4 (Right Hand)"},
           ),
           PracticeStep(
-            notes: [67],
-            type: StepType.sequential,
+            notes: [_note(67)],
             metadata: {"displayName": "Degree 5 (Right Hand)"},
           ),
           PracticeStep(
-            notes: [69],
-            type: StepType.sequential,
+            notes: [_note(69)],
             metadata: {"displayName": "Degree 6 (Right Hand)"},
           ),
           PracticeStep(
-            notes: [71],
-            type: StepType.sequential,
+            notes: [_note(71)],
             metadata: {"displayName": "Degree 7 (Right Hand)"},
           ),
           PracticeStep(
-            notes: [72],
-            type: StepType.sequential,
+            notes: [_note(72)],
             metadata: {"displayName": "Degree 8 (Right Hand)"},
           ),
         ],
@@ -89,13 +85,11 @@ void main() {
       final testExercise = PracticeExercise(
         steps: [
           PracticeStep(
-            notes: [60, 64, 67],
-            type: StepType.simultaneous,
+            notes: [_note(60), _note(64), _note(67)],
             metadata: {"displayName": "I: C Major"},
           ),
           PracticeStep(
-            notes: [67, 71, 74],
-            type: StepType.simultaneous,
+            notes: [_note(67), _note(71), _note(74)],
             metadata: {"displayName": "V: G Major"},
           ),
         ],


### PR DESCRIPTION
- Updated ArpeggiosStrategy, ChordProgressionsStrategy, ChordsByKeyStrategy, ChordsByTypeStrategy, DominantCadenceStrategy, and ScalesStrategy to use PracticeNote for note representation, enhancing clarity and consistency.
- Removed redundant metadata fields related to hand and finger numbers, now derived directly from PracticeNote.
- Improved accessibility utilities to reflect changes in note representation.
- Added comprehensive tests for PracticeNote and related strategies to ensure correct functionality and adherence to new structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Practice exercises now support structured notes with pitch, hand, optional fingering, and annotations.
  * Added consistent support for scales, chords, arpeggios, and cadences across hand selections.
  * Practice steps now advance only when the exact expected notes are held.

* **Bug Fixes**
  * Prevented errors when optional fingering labels are unavailable.
  * Improved accessibility descriptions for practice steps.

* **Documentation**
  * Added a comprehensive specification for exercise sequencing and evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->