### PR TITLE
Add progress tracking technique tree

### DIFF
--- a/docs/specifications/practice-step-duration.md
+++ b/docs/specifications/practice-step-duration.md
@@ -61,7 +61,7 @@ class PracticeStep {
 }
 ```
 
-Update the model's equality, `copyWith`, JSON conversion, and test fixtures accordingly. Existing strategy code may remain unchanged because it receives the quarter-note default. Strategies for chord-progressions should explicitly emit `noteValue: PracticeStepNoteValue.whole` where the intended rhythm is one chord per whole note. Other values are opt-in per exercise definition.
+Update the model's equality, `copyWith`, JSON conversion, and test fixtures accordingly. Strategies for chord-progressions should explicitly emit `noteValue: PracticeStepNoteValue.whole` where the intended rhythm is one chord per whole note. Scale steps should explicitly emit `PracticeStepNoteValue.eighth` when each note is played as an eighth note. Other values are opt-in per exercise definition.
 
 ## JSON and backward compatibility
 
@@ -122,7 +122,7 @@ Add focused tests for:
 2. JSON without `noteValue` deserializes to `quarter`.
 3. JSON round-trips every supported value and newly serialized steps include it.
 4. Conversion helpers return 4, 2, 1, 0.5, and 0.25 quarter-note beats.
-5. Existing generators retain quarter-note steps without source changes.
+5. Existing generators retain quarter-note steps unless their intended rhythm is explicitly defined.
 6. A chord-progression generator can deliberately emit whole-note steps.
 7. Tempo conversion reports the same 120 BPM for the three examples above.
 8. Mixed-note-value exercises return no tempo BPM and the `unavailable` quality; they do not fail exercise completion.
@@ -143,6 +143,6 @@ Add focused tests for:
 1. Add `PracticeStepNoteValue`, the `PracticeStep.noteValue` default, serialization support, and model tests.
 2. Add `PracticeExercise.uniformTempoNoteValue` and make the tempo tracker consume it for BPM conversion; persist the value with tempo results.
 3. Mark mixed-duration exercises as tempo `unavailable` and cover the behaviour with tests.
-4. Update intended chord-progression exercise definitions to explicitly use `whole`; leave all other generators unchanged until their rhythm is intentionally defined.
+4. Update intended chord-progression exercise definitions to explicitly use `whole`, and scale definitions to explicitly use `eighth`; leave other generators unchanged until their rhythm is intentionally defined.
 
 This keeps the change small: the existing `PracticeExercise`/`PracticeStep` pipeline remains the execution engine, while rhythm metadata provides the interpretation needed for tempo recording and later skill proficiency.

--- a/lib/application/skill_progression/default_skill_catalogue.dart
+++ b/lib/application/skill_progression/default_skill_catalogue.dart
@@ -1,0 +1,300 @@
+import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/music/scale_types.dart" as music;
+import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
+import "package:piano_fitness/domain/models/practice/exercise_tempo_result.dart";
+import "package:piano_fitness/domain/models/practice/practice_mode.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+import "package:piano_fitness/domain/services/music_theory/arpeggios.dart";
+import "package:piano_fitness/domain/services/music_theory/note_utils.dart";
+import "package:piano_fitness/domain/services/skill_progression/skill_catalogue_validator.dart";
+
+/// The first, deliberately small catalogue backed by existing exercise modes.
+abstract final class DefaultSkillCatalogue {
+  static final SkillCatalogue catalogue = _create();
+
+  static SkillCatalogue _create() {
+    final catalogue = SkillCatalogue(
+      id: "piano-fitness-foundations",
+      version: 2,
+      groups: const [
+        SkillGraphGroup(
+          id: "key-foundations",
+          name: "Key Foundations",
+          description: "Scales and arpeggios across every key.",
+          nodeIds: [
+            "major-scale-apart",
+            "major-scale",
+            "natural-minor",
+            "major-arpeggio",
+          ],
+          displayOrder: 0,
+        ),
+        SkillGraphGroup(
+          id: "chord-vocabulary",
+          name: "Chord Vocabulary",
+          description: "Diatonic chords, progressions, and cadences.",
+          nodeIds: ["diatonic-triads", "i-v-vi-iv", "dominant-cadence"],
+          displayOrder: 1,
+        ),
+      ],
+      nodes: [
+        SkillNode(
+          id: "major-scale-apart",
+          name: "Major scale, hands apart",
+          description: "Build secure scale technique one hand at a time.",
+          checkpoints: _scaleCheckpoints(
+            "major-scale-apart",
+            music.ScaleType.major,
+            handsApart: true,
+          ),
+          proficiencyRule: const SkillProficiencyRule(referenceTempoBpm: 100),
+          tempoProgression: const TempoProgression(incrementBpm: 5),
+        ),
+        SkillNode(
+          id: "major-scale",
+          name: "Major scale, hands together",
+          description: "Coordinate both hands through every major scale.",
+          checkpoints: _scaleCheckpoints("major-scale", music.ScaleType.major),
+          proficiencyRule: const SkillProficiencyRule(referenceTempoBpm: 90),
+          tempoProgression: const TempoProgression(incrementBpm: 5),
+          relations: const [
+            SkillRelation(
+              type: SkillRelationType.recommendedPrerequisite,
+              nodeId: "major-scale-apart",
+              description: "Secure each hand separately first.",
+            ),
+          ],
+        ),
+        SkillNode(
+          id: "natural-minor",
+          name: "Natural minor scale, hands together",
+          description: "Practise the natural minor sound across every key.",
+          checkpoints: _scaleCheckpoints(
+            "natural-minor",
+            music.ScaleType.minor,
+          ),
+          proficiencyRule: const SkillProficiencyRule(referenceTempoBpm: 90),
+          tempoProgression: const TempoProgression(incrementBpm: 5),
+          relations: const [
+            SkillRelation(
+              type: SkillRelationType.recommendedPrerequisite,
+              nodeId: "major-scale",
+            ),
+          ],
+        ),
+        SkillNode(
+          id: "major-arpeggio",
+          name: "One-octave major arpeggio",
+          description: "Connect chord tones as a smooth broken chord.",
+          checkpoints: _arpeggioCheckpoints(),
+          proficiencyRule: const SkillProficiencyRule(
+            referenceTempoBpm: 90,
+            supportedTempoMeasurementVersions: {
+              TempoMeasurementVersions.declaredStepDurations,
+              TempoMeasurementVersions.scaleEighthNotes,
+            },
+          ),
+          tempoProgression: const TempoProgression(incrementBpm: 5),
+          relations: const [
+            SkillRelation(
+              type: SkillRelationType.related,
+              nodeId: "major-scale",
+            ),
+          ],
+        ),
+        SkillNode(
+          id: "diatonic-triads",
+          name: "Diatonic triads",
+          description: "Play the seven triads in order in each major key.",
+          checkpoints: _chordsByKeyCheckpoints(),
+          proficiencyRule: const SkillProficiencyRule(
+            referenceTempoBpm: 72,
+            supportedTempoMeasurementVersions: {
+              TempoMeasurementVersions.declaredStepDurations,
+              TempoMeasurementVersions.scaleEighthNotes,
+            },
+          ),
+          tempoProgression: const TempoProgression(incrementBpm: 4),
+          relations: const [
+            SkillRelation(
+              type: SkillRelationType.recommendedPrerequisite,
+              nodeId: "major-scale",
+            ),
+          ],
+        ),
+        SkillNode(
+          id: "i-v-vi-iv",
+          name: "I–V–vi–IV progression",
+          description: "Practise a foundational four-chord pop progression.",
+          checkpoints: _progressionCheckpoints(),
+          proficiencyRule: const SkillProficiencyRule(
+            tempoEvidencePolicy: TempoEvidencePolicy.optional,
+            supportedTempoMeasurementVersions: {
+              TempoMeasurementVersions.declaredStepDurations,
+              TempoMeasurementVersions.scaleEighthNotes,
+            },
+          ),
+          relations: const [
+            SkillRelation(
+              type: SkillRelationType.appliesIn,
+              nodeId: "diatonic-triads",
+            ),
+          ],
+        ),
+        SkillNode(
+          id: "dominant-cadence",
+          name: "Dominant cadence",
+          description: "Resolve V to I through its inversions in every key.",
+          checkpoints: _cadenceCheckpoints(),
+          proficiencyRule: const SkillProficiencyRule(
+            tempoEvidencePolicy: TempoEvidencePolicy.notApplicable,
+            supportedTempoMeasurementVersions: {},
+          ),
+          relations: const [
+            SkillRelation(
+              type: SkillRelationType.recommendedPrerequisite,
+              nodeId: "diatonic-triads",
+            ),
+          ],
+        ),
+      ],
+    );
+    SkillCatalogueValidator.validate(catalogue);
+    return catalogue;
+  }
+
+  static List<SkillCheckpoint> _scaleCheckpoints(
+    String nodeId,
+    music.ScaleType scaleType, {
+    bool handsApart = false,
+  }) {
+    return music.Key.values
+        .map((key) {
+          ExerciseConfiguration configuration(HandSelection hand) =>
+              ExerciseConfiguration(
+                practiceMode: PracticeMode.scales,
+                handSelection: hand,
+                key: key,
+                scaleType: scaleType,
+              );
+          final exercises = handsApart
+              ? [
+                  SkillExercise(
+                    id: "$nodeId-${key.name}-left",
+                    name: "${key.displayName} major, left hand",
+                    configuration: configuration(HandSelection.left),
+                  ),
+                  SkillExercise(
+                    id: "$nodeId-${key.name}-right",
+                    name: "${key.displayName} major, right hand",
+                    configuration: configuration(HandSelection.right),
+                  ),
+                ]
+              : [
+                  SkillExercise(
+                    id: "$nodeId-${key.name}",
+                    name: "${key.displayName} ${scaleType.name} scale",
+                    configuration: configuration(HandSelection.both),
+                  ),
+                ];
+          return SkillCheckpoint(
+            id: "$nodeId-${key.name}",
+            name: "${key.displayName} ${scaleType.name}",
+            exercises: exercises,
+          );
+        })
+        .toList(growable: false);
+  }
+
+  static List<SkillCheckpoint> _arpeggioCheckpoints() {
+    return music.Key.values
+        .map((key) {
+          final root = MusicalNote.values[key.index];
+          return SkillCheckpoint(
+            id: "major-arpeggio-${key.name}",
+            name: "${key.displayName} major",
+            exercises: [
+              SkillExercise(
+                id: "major-arpeggio-${key.name}",
+                name: "${key.displayName} major arpeggio",
+                configuration: ExerciseConfiguration(
+                  practiceMode: PracticeMode.arpeggios,
+                  handSelection: HandSelection.both,
+                  musicalNote: root,
+                  arpeggioType: ArpeggioType.major,
+                ),
+              ),
+            ],
+          );
+        })
+        .toList(growable: false);
+  }
+
+  static List<SkillCheckpoint> _chordsByKeyCheckpoints() {
+    return music.Key.values
+        .map((key) {
+          return SkillCheckpoint(
+            id: "diatonic-triads-${key.name}",
+            name: "${key.displayName} major",
+            exercises: [
+              SkillExercise(
+                id: "diatonic-triads-${key.name}",
+                name: "${key.displayName} major diatonic triads",
+                configuration: ExerciseConfiguration(
+                  practiceMode: PracticeMode.chordsByKey,
+                  handSelection: HandSelection.both,
+                  key: key,
+                  scaleType: music.ScaleType.major,
+                ),
+              ),
+            ],
+          );
+        })
+        .toList(growable: false);
+  }
+
+  static List<SkillCheckpoint> _progressionCheckpoints() {
+    return music.Key.values
+        .map((key) {
+          return SkillCheckpoint(
+            id: "i-v-vi-iv-${key.name}",
+            name: "${key.displayName} major",
+            exercises: [
+              SkillExercise(
+                id: "i-v-vi-iv-${key.name}",
+                name: "${key.displayName}: I–V–vi–IV",
+                configuration: ExerciseConfiguration(
+                  practiceMode: PracticeMode.chordProgressions,
+                  handSelection: HandSelection.both,
+                  key: key,
+                  chordProgressionId: "I - V - vi - IV",
+                ),
+              ),
+            ],
+          );
+        })
+        .toList(growable: false);
+  }
+
+  static List<SkillCheckpoint> _cadenceCheckpoints() {
+    return music.Key.values
+        .map((key) {
+          return SkillCheckpoint(
+            id: "dominant-cadence-${key.name}",
+            name: "${key.displayName} major",
+            exercises: [
+              SkillExercise(
+                id: "dominant-cadence-${key.name}",
+                name: "${key.displayName}: V–I cadence",
+                configuration: ExerciseConfiguration(
+                  practiceMode: PracticeMode.dominantCadence,
+                  handSelection: HandSelection.both,
+                  key: key,
+                ),
+              ),
+            ],
+          );
+        })
+        .toList(growable: false);
+  }
+}

--- a/lib/application/skill_progression/default_skill_catalogue.dart
+++ b/lib/application/skill_progression/default_skill_catalogue.dart
@@ -16,7 +16,7 @@ abstract final class DefaultSkillCatalogue {
     final catalogue = SkillCatalogue(
       id: "piano-fitness-foundations",
       version: 2,
-      groups: const [
+      groups: [
         SkillGraphGroup(
           id: "key-foundations",
           name: "Key Foundations",
@@ -47,7 +47,7 @@ abstract final class DefaultSkillCatalogue {
             music.ScaleType.major,
             handsApart: true,
           ),
-          proficiencyRule: const SkillProficiencyRule(referenceTempoBpm: 100),
+          proficiencyRule: SkillProficiencyRule(referenceTempoBpm: 100),
           tempoProgression: const TempoProgression(incrementBpm: 5),
         ),
         SkillNode(
@@ -55,7 +55,7 @@ abstract final class DefaultSkillCatalogue {
           name: "Major scale, hands together",
           description: "Coordinate both hands through every major scale.",
           checkpoints: _scaleCheckpoints("major-scale", music.ScaleType.major),
-          proficiencyRule: const SkillProficiencyRule(referenceTempoBpm: 90),
+          proficiencyRule: SkillProficiencyRule(referenceTempoBpm: 90),
           tempoProgression: const TempoProgression(incrementBpm: 5),
           relations: const [
             SkillRelation(
@@ -73,7 +73,7 @@ abstract final class DefaultSkillCatalogue {
             "natural-minor",
             music.ScaleType.minor,
           ),
-          proficiencyRule: const SkillProficiencyRule(referenceTempoBpm: 90),
+          proficiencyRule: SkillProficiencyRule(referenceTempoBpm: 90),
           tempoProgression: const TempoProgression(incrementBpm: 5),
           relations: const [
             SkillRelation(
@@ -87,7 +87,7 @@ abstract final class DefaultSkillCatalogue {
           name: "One-octave major arpeggio",
           description: "Connect chord tones as a smooth broken chord.",
           checkpoints: _arpeggioCheckpoints(),
-          proficiencyRule: const SkillProficiencyRule(
+          proficiencyRule: SkillProficiencyRule(
             referenceTempoBpm: 90,
             supportedTempoMeasurementVersions: {
               TempoMeasurementVersions.declaredStepDurations,
@@ -107,7 +107,7 @@ abstract final class DefaultSkillCatalogue {
           name: "Diatonic triads",
           description: "Play the seven triads in order in each major key.",
           checkpoints: _chordsByKeyCheckpoints(),
-          proficiencyRule: const SkillProficiencyRule(
+          proficiencyRule: SkillProficiencyRule(
             referenceTempoBpm: 72,
             supportedTempoMeasurementVersions: {
               TempoMeasurementVersions.declaredStepDurations,
@@ -127,7 +127,7 @@ abstract final class DefaultSkillCatalogue {
           name: "I–V–vi–IV progression",
           description: "Practise a foundational four-chord pop progression.",
           checkpoints: _progressionCheckpoints(),
-          proficiencyRule: const SkillProficiencyRule(
+          proficiencyRule: SkillProficiencyRule(
             tempoEvidencePolicy: TempoEvidencePolicy.optional,
             supportedTempoMeasurementVersions: {
               TempoMeasurementVersions.declaredStepDurations,
@@ -146,7 +146,7 @@ abstract final class DefaultSkillCatalogue {
           name: "Dominant cadence",
           description: "Resolve V to I through its inversions in every key.",
           checkpoints: _cadenceCheckpoints(),
-          proficiencyRule: const SkillProficiencyRule(
+          proficiencyRule: SkillProficiencyRule(
             tempoEvidencePolicy: TempoEvidencePolicy.notApplicable,
             supportedTempoMeasurementVersions: {},
           ),
@@ -181,12 +181,12 @@ abstract final class DefaultSkillCatalogue {
               ? [
                   SkillExercise(
                     id: "$nodeId-${key.name}-left",
-                    name: "${key.displayName} major, left hand",
+                    name: "${key.displayName} ${scaleType.name}, left hand",
                     configuration: configuration(HandSelection.left),
                   ),
                   SkillExercise(
                     id: "$nodeId-${key.name}-right",
-                    name: "${key.displayName} major, right hand",
+                    name: "${key.displayName} ${scaleType.name}, right hand",
                     configuration: configuration(HandSelection.right),
                   ),
                 ]
@@ -209,7 +209,7 @@ abstract final class DefaultSkillCatalogue {
   static List<SkillCheckpoint> _arpeggioCheckpoints() {
     return music.Key.values
         .map((key) {
-          final root = MusicalNote.values[key.index];
+          final root = NoteUtils.keyToMusicalNote(key);
           return SkillCheckpoint(
             id: "major-arpeggio-${key.name}",
             name: "${key.displayName} major",

--- a/lib/domain/models/practice/exercise_tempo_result.dart
+++ b/lib/domain/models/practice/exercise_tempo_result.dart
@@ -22,7 +22,12 @@ abstract final class TempoMeasurementThresholds {
 /// Versions of the persisted tempo calculation algorithm.
 abstract final class TempoMeasurementVersions {
   /// Version 2 converts declared step note values to quarter-note BPM.
-  static const current = 2;
+  static const declaredStepDurations = 2;
+
+  /// Version 3 explicitly defines scale-note onsets as eighth notes.
+  static const scaleEighthNotes = 3;
+
+  static const current = scaleEighthNotes;
 }
 
 /// Statistical evidence derived from the onsets of one exercise attempt.

--- a/lib/domain/models/practice/strategies/scales_strategy.dart
+++ b/lib/domain/models/practice/strategies/scales_strategy.dart
@@ -72,6 +72,7 @@ class ScalesStrategy implements PracticeStrategy {
           final degree = (i ~/ 2) + 1;
           steps.add(
             PracticeStep(
+              noteValue: PracticeStepNoteValue.eighth,
               notes: [
                 PracticeNote(
                   pitch: MidiNote(sequence[i]),
@@ -104,6 +105,7 @@ class ScalesStrategy implements PracticeStrategy {
             : "Right";
         steps.add(
           PracticeStep(
+            noteValue: PracticeStepNoteValue.eighth,
             notes: [
               PracticeNote(
                 pitch: MidiNote(sequence[i]),

--- a/lib/domain/models/skill_progression/skill_catalogue.dart
+++ b/lib/domain/models/skill_progression/skill_catalogue.dart
@@ -5,12 +5,13 @@ import "package:piano_fitness/domain/models/practice/exercise_tempo_result.dart"
 /// A versioned, curated collection of piano skills.
 @immutable
 class SkillCatalogue {
-  const SkillCatalogue({
+  SkillCatalogue({
     required this.id,
     required this.version,
-    required this.nodes,
-    this.groups = const [],
-  });
+    required List<SkillNode> nodes,
+    List<SkillGraphGroup> groups = const [],
+  }) : nodes = List.unmodifiable(nodes),
+       groups = List.unmodifiable(groups);
 
   final String id;
   final int version;
@@ -21,13 +22,13 @@ class SkillCatalogue {
 /// Presentation-only grouping for related skill nodes.
 @immutable
 class SkillGraphGroup {
-  const SkillGraphGroup({
+  SkillGraphGroup({
     required this.id,
     required this.name,
     required this.description,
-    required this.nodeIds,
+    required List<String> nodeIds,
     this.displayOrder,
-  });
+  }) : nodeIds = List.unmodifiable(nodeIds);
 
   final String id;
   final String name;
@@ -39,16 +40,18 @@ class SkillGraphGroup {
 /// A freely accessible technique in the skill catalogue.
 @immutable
 class SkillNode {
-  const SkillNode({
+  SkillNode({
     required this.id,
     required this.name,
     required this.description,
-    required this.checkpoints,
+    required List<SkillCheckpoint> checkpoints,
     required this.proficiencyRule,
     this.tempoProgression,
-    this.relations = const [],
-    this.groupIds = const [],
-  });
+    List<SkillRelation> relations = const [],
+    List<String> groupIds = const [],
+  }) : checkpoints = List.unmodifiable(checkpoints),
+       relations = List.unmodifiable(relations),
+       groupIds = List.unmodifiable(groupIds);
 
   final String id;
   final String name;
@@ -63,11 +66,11 @@ class SkillNode {
 /// A separately tracked variation of a skill, usually a musical key.
 @immutable
 class SkillCheckpoint {
-  const SkillCheckpoint({
+  SkillCheckpoint({
     required this.id,
     required this.name,
-    required this.exercises,
-  });
+    required List<SkillExercise> exercises,
+  }) : exercises = List.unmodifiable(exercises);
 
   final String id;
   final String name;
@@ -115,15 +118,17 @@ enum TempoEvidencePolicy { required, optional, notApplicable }
 /// The positive evidence required to establish proficiency for a skill.
 @immutable
 class SkillProficiencyRule {
-  const SkillProficiencyRule({
+  SkillProficiencyRule({
     this.minimumAccuracy = 90,
     this.evidenceAttemptCount = 3,
     this.tempoEvidencePolicy = TempoEvidencePolicy.required,
-    this.supportedTempoMeasurementVersions = const {
+    Set<int> supportedTempoMeasurementVersions = const {
       TempoMeasurementVersions.current,
     },
     this.referenceTempoBpm,
-  });
+  }) : supportedTempoMeasurementVersions = Set.unmodifiable(
+         supportedTempoMeasurementVersions,
+       );
 
   final double minimumAccuracy;
   final int evidenceAttemptCount;

--- a/lib/domain/models/skill_progression/skill_catalogue.dart
+++ b/lib/domain/models/skill_progression/skill_catalogue.dart
@@ -1,0 +1,147 @@
+import "package:meta/meta.dart";
+import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
+import "package:piano_fitness/domain/models/practice/exercise_tempo_result.dart";
+
+/// A versioned, curated collection of piano skills.
+@immutable
+class SkillCatalogue {
+  const SkillCatalogue({
+    required this.id,
+    required this.version,
+    required this.nodes,
+    this.groups = const [],
+  });
+
+  final String id;
+  final int version;
+  final List<SkillNode> nodes;
+  final List<SkillGraphGroup> groups;
+}
+
+/// Presentation-only grouping for related skill nodes.
+@immutable
+class SkillGraphGroup {
+  const SkillGraphGroup({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.nodeIds,
+    this.displayOrder,
+  });
+
+  final String id;
+  final String name;
+  final String description;
+  final List<String> nodeIds;
+  final int? displayOrder;
+}
+
+/// A freely accessible technique in the skill catalogue.
+@immutable
+class SkillNode {
+  const SkillNode({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.checkpoints,
+    required this.proficiencyRule,
+    this.tempoProgression,
+    this.relations = const [],
+    this.groupIds = const [],
+  });
+
+  final String id;
+  final String name;
+  final String description;
+  final List<SkillCheckpoint> checkpoints;
+  final SkillProficiencyRule proficiencyRule;
+  final TempoProgression? tempoProgression;
+  final List<SkillRelation> relations;
+  final List<String> groupIds;
+}
+
+/// A separately tracked variation of a skill, usually a musical key.
+@immutable
+class SkillCheckpoint {
+  const SkillCheckpoint({
+    required this.id,
+    required this.name,
+    required this.exercises,
+  });
+
+  final String id;
+  final String name;
+  final List<SkillExercise> exercises;
+}
+
+/// An exact existing exercise configuration that can be opened for practice.
+@immutable
+class SkillExercise {
+  const SkillExercise({
+    required this.id,
+    required this.name,
+    required this.configuration,
+  });
+
+  final String id;
+  final String name;
+  final ExerciseConfiguration configuration;
+}
+
+/// The non-blocking relationship between two skills.
+@immutable
+class SkillRelation {
+  const SkillRelation({
+    required this.type,
+    required this.nodeId,
+    this.description,
+  });
+
+  final SkillRelationType type;
+  final String nodeId;
+  final String? description;
+}
+
+enum SkillRelationType {
+  recommendedPrerequisite,
+  variation,
+  related,
+  appliesIn,
+}
+
+/// Determines whether reliable measured tempo is needed for proficiency.
+enum TempoEvidencePolicy { required, optional, notApplicable }
+
+/// The positive evidence required to establish proficiency for a skill.
+@immutable
+class SkillProficiencyRule {
+  const SkillProficiencyRule({
+    this.minimumAccuracy = 90,
+    this.evidenceAttemptCount = 3,
+    this.tempoEvidencePolicy = TempoEvidencePolicy.required,
+    this.supportedTempoMeasurementVersions = const {
+      TempoMeasurementVersions.current,
+    },
+    this.referenceTempoBpm,
+  });
+
+  final double minimumAccuracy;
+  final int evidenceAttemptCount;
+  final TempoEvidencePolicy tempoEvidencePolicy;
+  final Set<int> supportedTempoMeasurementVersions;
+  final double? referenceTempoBpm;
+}
+
+/// Optional, non-blocking tempo recommendation metadata.
+@immutable
+class TempoProgression {
+  const TempoProgression({
+    required this.incrementBpm,
+    this.minimumBpm,
+    this.referenceBpm,
+  });
+
+  final int incrementBpm;
+  final int? minimumBpm;
+  final int? referenceBpm;
+}

--- a/lib/domain/models/skill_progression/skill_proficiency_snapshot.dart
+++ b/lib/domain/models/skill_progression/skill_proficiency_snapshot.dart
@@ -6,42 +6,69 @@ import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.da
 class SkillExerciseProficiency {
   const SkillExerciseProficiency({
     required this.exercise,
-    required this.accuracyQualifyingAttemptCount,
-    required this.reliableTempoAttemptCount,
-    required this.progressionQualifyingAttemptCount,
+    required this.evidence,
     required this.recentAverageAccuracy,
-    required this.recentAverageMeasuredBpm,
-    required this.historicalBestMeasuredBpm,
+    required this.tempo,
     required this.hasSufficientAccuracyEvidence,
     required this.hasSufficientTempoEvidence,
     required this.hasEstablishedProficiency,
     required this.positiveScore,
-    required this.suggestedNextTempoBpm,
   });
 
   final SkillExercise exercise;
-  final int accuracyQualifyingAttemptCount;
-  final int reliableTempoAttemptCount;
-  final int progressionQualifyingAttemptCount;
+  final SkillEvidenceCounts evidence;
   final double? recentAverageAccuracy;
-  final double? recentAverageMeasuredBpm;
-  final double? historicalBestMeasuredBpm;
+  final SkillTempoEvidence tempo;
   final bool hasSufficientAccuracyEvidence;
   final bool hasSufficientTempoEvidence;
   final bool hasEstablishedProficiency;
   final double positiveScore;
+
+  int get accuracyQualifyingAttemptCount => evidence.accuracyQualifying;
+  int get reliableTempoAttemptCount => evidence.reliableTempo;
+  int get progressionQualifyingAttemptCount => evidence.progressionQualifying;
+  double? get recentAverageMeasuredBpm => tempo.recentAverageMeasuredBpm;
+  double? get historicalBestMeasuredBpm => tempo.historicalBestMeasuredBpm;
+  double? get suggestedNextTempoBpm => tempo.suggestedNextTempoBpm;
+}
+
+/// Counts of qualifying historical attempts for one skill exercise.
+@immutable
+class SkillEvidenceCounts {
+  const SkillEvidenceCounts({
+    required this.accuracyQualifying,
+    required this.reliableTempo,
+    required this.progressionQualifying,
+  });
+
+  final int accuracyQualifying;
+  final int reliableTempo;
+  final int progressionQualifying;
+}
+
+/// Compatible reliable tempo evidence for one skill exercise.
+@immutable
+class SkillTempoEvidence {
+  const SkillTempoEvidence({
+    required this.recentAverageMeasuredBpm,
+    required this.historicalBestMeasuredBpm,
+    required this.suggestedNextTempoBpm,
+  });
+
+  final double? recentAverageMeasuredBpm;
+  final double? historicalBestMeasuredBpm;
   final double? suggestedNextTempoBpm;
 }
 
 /// Derived proficiency for all exercises in a checkpoint.
 @immutable
 class SkillCheckpointProficiency {
-  const SkillCheckpointProficiency({
+  SkillCheckpointProficiency({
     required this.checkpoint,
-    required this.exerciseProficiencies,
+    required List<SkillExerciseProficiency> exerciseProficiencies,
     required this.hasEstablishedProficiency,
     required this.positiveScore,
-  });
+  }) : exerciseProficiencies = List.unmodifiable(exerciseProficiencies);
 
   final SkillCheckpoint checkpoint;
   final List<SkillExerciseProficiency> exerciseProficiencies;
@@ -52,14 +79,14 @@ class SkillCheckpointProficiency {
 /// Derived proficiency and key coverage for a catalogue node.
 @immutable
 class SkillNodeProficiency {
-  const SkillNodeProficiency({
+  SkillNodeProficiency({
     required this.node,
-    required this.checkpointProficiencies,
+    required List<SkillCheckpointProficiency> checkpointProficiencies,
     required this.establishedCheckpointCount,
     required this.recentAverageAccuracy,
     required this.recentAverageMeasuredBpm,
     required this.positiveScore,
-  });
+  }) : checkpointProficiencies = List.unmodifiable(checkpointProficiencies);
 
   final SkillNode node;
   final List<SkillCheckpointProficiency> checkpointProficiencies;

--- a/lib/domain/models/skill_progression/skill_proficiency_snapshot.dart
+++ b/lib/domain/models/skill_progression/skill_proficiency_snapshot.dart
@@ -1,0 +1,72 @@
+import "package:meta/meta.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+
+/// Derived proficiency for one exact exercise configuration.
+@immutable
+class SkillExerciseProficiency {
+  const SkillExerciseProficiency({
+    required this.exercise,
+    required this.accuracyQualifyingAttemptCount,
+    required this.reliableTempoAttemptCount,
+    required this.progressionQualifyingAttemptCount,
+    required this.recentAverageAccuracy,
+    required this.recentAverageMeasuredBpm,
+    required this.historicalBestMeasuredBpm,
+    required this.hasSufficientAccuracyEvidence,
+    required this.hasSufficientTempoEvidence,
+    required this.hasEstablishedProficiency,
+    required this.positiveScore,
+    required this.suggestedNextTempoBpm,
+  });
+
+  final SkillExercise exercise;
+  final int accuracyQualifyingAttemptCount;
+  final int reliableTempoAttemptCount;
+  final int progressionQualifyingAttemptCount;
+  final double? recentAverageAccuracy;
+  final double? recentAverageMeasuredBpm;
+  final double? historicalBestMeasuredBpm;
+  final bool hasSufficientAccuracyEvidence;
+  final bool hasSufficientTempoEvidence;
+  final bool hasEstablishedProficiency;
+  final double positiveScore;
+  final double? suggestedNextTempoBpm;
+}
+
+/// Derived proficiency for all exercises in a checkpoint.
+@immutable
+class SkillCheckpointProficiency {
+  const SkillCheckpointProficiency({
+    required this.checkpoint,
+    required this.exerciseProficiencies,
+    required this.hasEstablishedProficiency,
+    required this.positiveScore,
+  });
+
+  final SkillCheckpoint checkpoint;
+  final List<SkillExerciseProficiency> exerciseProficiencies;
+  final bool hasEstablishedProficiency;
+  final double positiveScore;
+}
+
+/// Derived proficiency and key coverage for a catalogue node.
+@immutable
+class SkillNodeProficiency {
+  const SkillNodeProficiency({
+    required this.node,
+    required this.checkpointProficiencies,
+    required this.establishedCheckpointCount,
+    required this.recentAverageAccuracy,
+    required this.recentAverageMeasuredBpm,
+    required this.positiveScore,
+  });
+
+  final SkillNode node;
+  final List<SkillCheckpointProficiency> checkpointProficiencies;
+  final int establishedCheckpointCount;
+  final double? recentAverageAccuracy;
+  final double? recentAverageMeasuredBpm;
+  final double positiveScore;
+
+  int get checkpointCount => checkpointProficiencies.length;
+}

--- a/lib/domain/services/skill_progression/exercise_configuration_identity.dart
+++ b/lib/domain/services/skill_progression/exercise_configuration_identity.dart
@@ -1,0 +1,102 @@
+import "package:meta/meta.dart";
+import "package:piano_fitness/domain/models/music/chord_tone_pattern.dart";
+import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
+import "package:piano_fitness/domain/models/practice/exercise_history_entry.dart";
+import "package:piano_fitness/domain/services/music_theory/arpeggios.dart";
+
+/// Stable comparison identity for a completed exercise configuration.
+///
+/// It normalises nullable historical defaults so old and new equivalent
+/// configurations match without a history migration.
+@immutable
+class ExerciseConfigurationIdentity {
+  const ExerciseConfigurationIdentity._(this.value);
+
+  factory ExerciseConfigurationIdentity.fromConfiguration(
+    ExerciseConfiguration configuration,
+  ) {
+    return ExerciseConfigurationIdentity._(
+      _build(
+        practiceMode: configuration.practiceMode.name,
+        handSelection: configuration.handSelection.name,
+        key: configuration.key?.name,
+        scaleType: configuration.scaleType?.name,
+        chordType: configuration.chordType?.name,
+        includeInversions: configuration.includeInversions,
+        includeSeventhChords: configuration.includeSeventhChords,
+        musicalNote: configuration.musicalNote?.name,
+        arpeggioType: configuration.arpeggioType?.name,
+        arpeggioOctaves: configuration.arpeggioOctaves.name,
+        pattern: configuration.pattern.name,
+        includeLeftHandRoot: configuration.includeLeftHandRoot,
+        chordProgressionId: configuration.chordProgressionId,
+      ),
+    );
+  }
+
+  factory ExerciseConfigurationIdentity.fromHistory(
+    ExerciseHistoryEntry entry,
+  ) {
+    return ExerciseConfigurationIdentity._(
+      _build(
+        practiceMode: entry.practiceMode.name,
+        handSelection: entry.handSelection.name,
+        key: entry.musicalKey?.name,
+        scaleType: entry.scaleType?.name,
+        chordType: entry.chordType?.name,
+        includeInversions: entry.includeInversions,
+        includeSeventhChords: entry.includeSeventhChords,
+        musicalNote: entry.musicalNote?.name,
+        arpeggioType: entry.arpeggioType?.name,
+        arpeggioOctaves: (entry.arpeggioOctaves ?? ArpeggioOctaves.one).name,
+        pattern: (entry.pattern ?? ChordTonePattern.straight).name,
+        includeLeftHandRoot: entry.includeLeftHandRoot,
+        chordProgressionId: entry.chordProgressionId,
+      ),
+    );
+  }
+
+  final String value;
+
+  static String _build({
+    required String practiceMode,
+    required String handSelection,
+    required String? key,
+    required String? scaleType,
+    required String? chordType,
+    required bool includeInversions,
+    required bool includeSeventhChords,
+    required String? musicalNote,
+    required String? arpeggioType,
+    required String arpeggioOctaves,
+    required String pattern,
+    required bool includeLeftHandRoot,
+    required String? chordProgressionId,
+  }) {
+    return [
+      practiceMode,
+      handSelection,
+      key ?? "",
+      scaleType ?? "",
+      chordType ?? "",
+      includeInversions,
+      includeSeventhChords,
+      musicalNote ?? "",
+      arpeggioType ?? "",
+      arpeggioOctaves,
+      pattern,
+      includeLeftHandRoot,
+      chordProgressionId ?? "",
+    ].join("|");
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is ExerciseConfigurationIdentity && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => value;
+}

--- a/lib/domain/services/skill_progression/exercise_configuration_identity.dart
+++ b/lib/domain/services/skill_progression/exercise_configuration_identity.dart
@@ -1,3 +1,5 @@
+import "dart:convert";
+
 import "package:meta/meta.dart";
 import "package:piano_fitness/domain/models/music/chord_tone_pattern.dart";
 import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
@@ -73,21 +75,21 @@ class ExerciseConfigurationIdentity {
     required bool includeLeftHandRoot,
     required String? chordProgressionId,
   }) {
-    return [
+    return jsonEncode([
       practiceMode,
       handSelection,
-      key ?? "",
-      scaleType ?? "",
-      chordType ?? "",
+      key,
+      scaleType,
+      chordType,
       includeInversions,
       includeSeventhChords,
-      musicalNote ?? "",
-      arpeggioType ?? "",
+      musicalNote,
+      arpeggioType,
       arpeggioOctaves,
       pattern,
       includeLeftHandRoot,
-      chordProgressionId ?? "",
-    ].join("|");
+      chordProgressionId,
+    ]);
   }
 
   @override

--- a/lib/domain/services/skill_progression/skill_catalogue_validator.dart
+++ b/lib/domain/services/skill_progression/skill_catalogue_validator.dart
@@ -1,0 +1,97 @@
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+import "package:piano_fitness/domain/services/skill_progression/exercise_configuration_identity.dart";
+
+/// Validates catalogue integrity before it is shown to learners.
+class SkillCatalogueValidator {
+  const SkillCatalogueValidator._();
+
+  static void validate(SkillCatalogue catalogue) {
+    if (catalogue.id.isEmpty || catalogue.version < 1) {
+      throw ArgumentError("A catalogue needs an id and a positive version.");
+    }
+
+    final nodeIds = <String>{};
+    final configurationIdentities = <ExerciseConfigurationIdentity>{};
+    for (final node in catalogue.nodes) {
+      if (node.id.isEmpty || !nodeIds.add(node.id)) {
+        throw ArgumentError("Skill node ids must be non-empty and unique.");
+      }
+      _validateRule(node.proficiencyRule);
+      final checkpointIds = <String>{};
+      for (final checkpoint in node.checkpoints) {
+        if (checkpoint.id.isEmpty || !checkpointIds.add(checkpoint.id)) {
+          throw ArgumentError("Checkpoint ids must be unique within a node.");
+        }
+        if (checkpoint.exercises.isEmpty) {
+          throw ArgumentError("Every checkpoint must contain an exercise.");
+        }
+        final exerciseIds = <String>{};
+        for (final exercise in checkpoint.exercises) {
+          if (exercise.id.isEmpty || !exerciseIds.add(exercise.id)) {
+            throw ArgumentError(
+              "Exercise ids must be unique within a checkpoint.",
+            );
+          }
+          exercise.configuration.validate();
+          if (!configurationIdentities.add(
+            ExerciseConfigurationIdentity.fromConfiguration(
+              exercise.configuration,
+            ),
+          )) {
+            throw ArgumentError(
+              "Each catalogue exercise must have a unique configuration.",
+            );
+          }
+        }
+      }
+    }
+
+    for (final node in catalogue.nodes) {
+      for (final relation in node.relations) {
+        if (!nodeIds.contains(relation.nodeId)) {
+          throw ArgumentError(
+            "Skill relation targets must exist in the catalogue.",
+          );
+        }
+      }
+    }
+
+    final groupIds = <String>{};
+    for (final group in catalogue.groups) {
+      if (group.id.isEmpty || !groupIds.add(group.id)) {
+        throw ArgumentError(
+          "Skill graph group ids must be non-empty and unique.",
+        );
+      }
+      for (final nodeId in group.nodeIds) {
+        if (!nodeIds.contains(nodeId)) {
+          throw ArgumentError(
+            "Skill graph groups may only reference known nodes.",
+          );
+        }
+      }
+    }
+  }
+
+  static void _validateRule(SkillProficiencyRule rule) {
+    if (rule.minimumAccuracy < 0 || rule.minimumAccuracy > 100) {
+      throw ArgumentError("Minimum accuracy must be between 0 and 100.");
+    }
+    if (rule.evidenceAttemptCount < 1) {
+      throw ArgumentError("At least one evidence attempt is required.");
+    }
+    if (rule.tempoEvidencePolicy == TempoEvidencePolicy.required &&
+        rule.supportedTempoMeasurementVersions.isEmpty) {
+      throw ArgumentError("Required tempo evidence needs a supported version.");
+    }
+    if (rule.tempoEvidencePolicy == TempoEvidencePolicy.notApplicable &&
+        rule.referenceTempoBpm != null) {
+      throw ArgumentError(
+        "Tempo-inapplicable skills cannot declare a reference BPM.",
+      );
+    }
+    if (rule.referenceTempoBpm != null && rule.referenceTempoBpm! <= 0) {
+      throw ArgumentError("Reference BPM must be positive.");
+    }
+  }
+}

--- a/lib/domain/services/skill_progression/skill_catalogue_validator.dart
+++ b/lib/domain/services/skill_progression/skill_catalogue_validator.dart
@@ -17,6 +17,9 @@ class SkillCatalogueValidator {
         throw ArgumentError("Skill node ids must be non-empty and unique.");
       }
       _validateRule(node.proficiencyRule);
+      if (node.checkpoints.isEmpty) {
+        throw ArgumentError("Every skill node must contain a checkpoint.");
+      }
       final checkpointIds = <String>{};
       for (final checkpoint in node.checkpoints) {
         if (checkpoint.id.isEmpty || !checkpointIds.add(checkpoint.id)) {
@@ -48,6 +51,9 @@ class SkillCatalogueValidator {
 
     for (final node in catalogue.nodes) {
       for (final relation in node.relations) {
+        if (relation.nodeId == node.id) {
+          throw ArgumentError("A skill node cannot relate to itself.");
+        }
         if (!nodeIds.contains(relation.nodeId)) {
           throw ArgumentError(
             "Skill relation targets must exist in the catalogue.",

--- a/lib/domain/services/skill_progression/skill_history_matcher.dart
+++ b/lib/domain/services/skill_progression/skill_history_matcher.dart
@@ -1,0 +1,23 @@
+import "package:piano_fitness/domain/models/practice/exercise_history_entry.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+import "package:piano_fitness/domain/services/skill_progression/exercise_configuration_identity.dart";
+
+/// Matches persisted attempts to catalogue exercises using completed settings.
+class SkillHistoryMatcher {
+  const SkillHistoryMatcher._();
+
+  static List<ExerciseHistoryEntry> entriesForExercise(
+    Iterable<ExerciseHistoryEntry> entries,
+    SkillExercise exercise,
+  ) {
+    final identity = ExerciseConfigurationIdentity.fromConfiguration(
+      exercise.configuration,
+    );
+    return entries
+        .where(
+          (entry) =>
+              ExerciseConfigurationIdentity.fromHistory(entry) == identity,
+        )
+        .toList(growable: false);
+  }
+}

--- a/lib/domain/services/skill_progression/skill_proficiency_evaluator.dart
+++ b/lib/domain/services/skill_progression/skill_proficiency_evaluator.dart
@@ -51,12 +51,17 @@ class SkillProficiencyEvaluator {
 
     return SkillExerciseProficiency(
       exercise: exercise,
-      accuracyQualifyingAttemptCount: accurate.length,
-      reliableTempoAttemptCount: reliableTempo.length,
-      progressionQualifyingAttemptCount: progression.length,
+      evidence: SkillEvidenceCounts(
+        accuracyQualifying: accurate.length,
+        reliableTempo: reliableTempo.length,
+        progressionQualifying: progression.length,
+      ),
       recentAverageAccuracy: _averageAccuracy(recentProgression),
-      recentAverageMeasuredBpm: _averageBpm(recentTempo),
-      historicalBestMeasuredBpm: bestTempo,
+      tempo: SkillTempoEvidence(
+        recentAverageMeasuredBpm: _averageBpm(recentTempo),
+        historicalBestMeasuredBpm: bestTempo,
+        suggestedNextTempoBpm: suggestedTempo,
+      ),
       hasSufficientAccuracyEvidence: hasAccuracy,
       hasSufficientTempoEvidence: hasTempo,
       hasEstablishedProficiency: established,
@@ -67,7 +72,6 @@ class SkillProficiencyEvaluator {
         bestTempo: bestTempo,
         referenceTempo: rule.referenceTempoBpm,
       ),
-      suggestedNextTempoBpm: suggestedTempo,
     );
   }
 
@@ -113,7 +117,8 @@ class SkillProficiencyEvaluator {
       recentAverageAccuracy: _averageNullable(
         exercises.map((exercise) => exercise.recentAverageAccuracy),
       ),
-      recentAverageMeasuredBpm: compatibleStepValues.length == 1
+      recentAverageMeasuredBpm:
+          compatibleStepValues.length == 1 && tempos.isNotEmpty
           ? _average(
               tempos.map((exercise) => exercise.recentAverageMeasuredBpm!),
             )
@@ -190,24 +195,19 @@ class SkillProficiencyEvaluator {
     SkillNode node,
     Iterable<ExerciseHistoryEntry> history,
   ) {
-    final exerciseIds = node.checkpoints
-        .expand((checkpoint) => checkpoint.exercises)
-        .map((exercise) => exercise.id)
-        .toSet();
     final values = <PracticeStepNoteValue>{};
     for (final checkpoint in node.checkpoints) {
       for (final exercise in checkpoint.exercises) {
-        final proficiency = evaluateExercise(node, exercise, history);
-        if (exerciseIds.contains(proficiency.exercise.id)) {
-          final entries = SkillHistoryMatcher.entriesForExercise(
-            history,
-            exercise,
-          );
-          for (final entry in entries) {
-            if (_hasCompatibleReliableTempo(entry, node.proficiencyRule) &&
-                entry.tempoStepNoteValue != null) {
-              values.add(entry.tempoStepNoteValue!);
-            }
+        final entries = SkillHistoryMatcher.entriesForExercise(
+          history,
+          exercise,
+        );
+        for (final entry in entries) {
+          if ((entry.accuracyPercentage ?? 0) >=
+                  node.proficiencyRule.minimumAccuracy &&
+              _hasCompatibleReliableTempo(entry, node.proficiencyRule) &&
+              entry.tempoStepNoteValue != null) {
+            values.add(entry.tempoStepNoteValue!);
           }
         }
       }

--- a/lib/domain/services/skill_progression/skill_proficiency_evaluator.dart
+++ b/lib/domain/services/skill_progression/skill_proficiency_evaluator.dart
@@ -1,0 +1,217 @@
+import "package:piano_fitness/domain/models/practice/exercise_history_entry.dart";
+import "package:piano_fitness/domain/models/practice/exercise_tempo_result.dart";
+import "package:piano_fitness/domain/models/practice/practice_step_note_value.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_proficiency_snapshot.dart";
+import "package:piano_fitness/domain/services/skill_progression/skill_history_matcher.dart";
+
+/// Derives positive skill proficiency from persisted exercise attempts.
+///
+/// This deliberately consumes stored tempo classifications rather than
+/// recalculating timing from MIDI events.
+class SkillProficiencyEvaluator {
+  const SkillProficiencyEvaluator._();
+
+  static SkillExerciseProficiency evaluateExercise(
+    SkillNode node,
+    SkillExercise exercise,
+    Iterable<ExerciseHistoryEntry> history,
+  ) {
+    final rule = node.proficiencyRule;
+    final entries = SkillHistoryMatcher.entriesForExercise(history, exercise)
+      ..sort((a, b) => b.completedAt.compareTo(a.completedAt));
+    final accurate = entries
+        .where(
+          (entry) => (entry.accuracyPercentage ?? 0) >= rule.minimumAccuracy,
+        )
+        .toList(growable: false);
+    final reliableTempo = accurate
+        .where((entry) => _hasCompatibleReliableTempo(entry, rule))
+        .toList(growable: false);
+    final progression = switch (rule.tempoEvidencePolicy) {
+      TempoEvidencePolicy.required => reliableTempo,
+      TempoEvidencePolicy.optional ||
+      TempoEvidencePolicy.notApplicable => accurate,
+    };
+    final recentProgression = progression.take(rule.evidenceAttemptCount);
+    final recentTempo = reliableTempo.take(rule.evidenceAttemptCount);
+    final hasAccuracy = accurate.length >= rule.evidenceAttemptCount;
+    final hasTempo = reliableTempo.length >= rule.evidenceAttemptCount;
+    final established = switch (rule.tempoEvidencePolicy) {
+      TempoEvidencePolicy.required => hasAccuracy && hasTempo,
+      TempoEvidencePolicy.optional ||
+      TempoEvidencePolicy.notApplicable => hasAccuracy,
+    };
+    final bestTempo = _maxBpm(reliableTempo);
+    final suggestedTempo = _suggestedTempo(
+      node.tempoProgression,
+      bestTempo,
+      rule.tempoEvidencePolicy,
+    );
+
+    return SkillExerciseProficiency(
+      exercise: exercise,
+      accuracyQualifyingAttemptCount: accurate.length,
+      reliableTempoAttemptCount: reliableTempo.length,
+      progressionQualifyingAttemptCount: progression.length,
+      recentAverageAccuracy: _averageAccuracy(recentProgression),
+      recentAverageMeasuredBpm: _averageBpm(recentTempo),
+      historicalBestMeasuredBpm: bestTempo,
+      hasSufficientAccuracyEvidence: hasAccuracy,
+      hasSufficientTempoEvidence: hasTempo,
+      hasEstablishedProficiency: established,
+      positiveScore: _positiveScore(
+        progressionCount: progression.length,
+        requiredCount: rule.evidenceAttemptCount,
+        established: established,
+        bestTempo: bestTempo,
+        referenceTempo: rule.referenceTempoBpm,
+      ),
+      suggestedNextTempoBpm: suggestedTempo,
+    );
+  }
+
+  static SkillCheckpointProficiency evaluateCheckpoint(
+    SkillNode node,
+    SkillCheckpoint checkpoint,
+    Iterable<ExerciseHistoryEntry> history,
+  ) {
+    final exercises = checkpoint.exercises
+        .map((exercise) => evaluateExercise(node, exercise, history))
+        .toList(growable: false);
+    final established = exercises.every(
+      (proficiency) => proficiency.hasEstablishedProficiency,
+    );
+    return SkillCheckpointProficiency(
+      checkpoint: checkpoint,
+      exerciseProficiencies: exercises,
+      hasEstablishedProficiency: established,
+      positiveScore: _average(exercises.map((item) => item.positiveScore)),
+    );
+  }
+
+  static SkillNodeProficiency evaluateNode(
+    SkillNode node,
+    Iterable<ExerciseHistoryEntry> history,
+  ) {
+    final checkpoints = node.checkpoints
+        .map((checkpoint) => evaluateCheckpoint(node, checkpoint, history))
+        .toList(growable: false);
+    final exercises = checkpoints.expand(
+      (checkpoint) => checkpoint.exerciseProficiencies,
+    );
+    final tempos = exercises
+        .where((exercise) => exercise.recentAverageMeasuredBpm != null)
+        .toList(growable: false);
+    final compatibleStepValues = _compatibleStepValues(node, history);
+    return SkillNodeProficiency(
+      node: node,
+      checkpointProficiencies: checkpoints,
+      establishedCheckpointCount: checkpoints
+          .where((checkpoint) => checkpoint.hasEstablishedProficiency)
+          .length,
+      recentAverageAccuracy: _averageNullable(
+        exercises.map((exercise) => exercise.recentAverageAccuracy),
+      ),
+      recentAverageMeasuredBpm: compatibleStepValues.length == 1
+          ? _average(
+              tempos.map((exercise) => exercise.recentAverageMeasuredBpm!),
+            )
+          : null,
+      positiveScore: _average(checkpoints.map((item) => item.positiveScore)),
+    );
+  }
+
+  static bool _hasCompatibleReliableTempo(
+    ExerciseHistoryEntry entry,
+    SkillProficiencyRule rule,
+  ) {
+    return entry.tempoMeasurementQuality == TempoMeasurementQuality.reliable &&
+        entry.measuredTempoBpm != null &&
+        entry.tempoMeasurementVersion != null &&
+        rule.supportedTempoMeasurementVersions.contains(
+          entry.tempoMeasurementVersion,
+        );
+  }
+
+  static double? _averageAccuracy(Iterable<ExerciseHistoryEntry> entries) =>
+      _averageNullable(entries.map((entry) => entry.accuracyPercentage));
+
+  static double? _averageBpm(Iterable<ExerciseHistoryEntry> entries) =>
+      _averageNullable(entries.map((entry) => entry.measuredTempoBpm));
+
+  static double? _maxBpm(Iterable<ExerciseHistoryEntry> entries) {
+    double? maximum;
+    for (final entry in entries) {
+      final bpm = entry.measuredTempoBpm;
+      if (bpm != null && (maximum == null || bpm > maximum)) maximum = bpm;
+    }
+    return maximum;
+  }
+
+  static double? _suggestedTempo(
+    TempoProgression? progression,
+    double? bestTempo,
+    TempoEvidencePolicy policy,
+  ) {
+    if (progression == null ||
+        bestTempo == null ||
+        policy == TempoEvidencePolicy.notApplicable) {
+      return null;
+    }
+    return bestTempo + progression.incrementBpm;
+  }
+
+  static double _positiveScore({
+    required int progressionCount,
+    required int requiredCount,
+    required bool established,
+    required double? bestTempo,
+    required double? referenceTempo,
+  }) {
+    if (progressionCount == 0) return 0;
+    if (!established) return (progressionCount / requiredCount) * 0.66;
+    if (referenceTempo == null || bestTempo == null) return 0.75;
+    return (0.75 + (bestTempo / referenceTempo).clamp(0, 1) * 0.25).clamp(0, 1);
+  }
+
+  static double _average(Iterable<double> values) {
+    final list = values.toList(growable: false);
+    if (list.isEmpty) return 0;
+    return list.reduce((sum, value) => sum + value) / list.length;
+  }
+
+  static double? _averageNullable(Iterable<double?> values) {
+    final present = values.whereType<double>().toList(growable: false);
+    return present.isEmpty ? null : _average(present);
+  }
+
+  static Set<PracticeStepNoteValue> _compatibleStepValues(
+    SkillNode node,
+    Iterable<ExerciseHistoryEntry> history,
+  ) {
+    final exerciseIds = node.checkpoints
+        .expand((checkpoint) => checkpoint.exercises)
+        .map((exercise) => exercise.id)
+        .toSet();
+    final values = <PracticeStepNoteValue>{};
+    for (final checkpoint in node.checkpoints) {
+      for (final exercise in checkpoint.exercises) {
+        final proficiency = evaluateExercise(node, exercise, history);
+        if (exerciseIds.contains(proficiency.exercise.id)) {
+          final entries = SkillHistoryMatcher.entriesForExercise(
+            history,
+            exercise,
+          );
+          for (final entry in entries) {
+            if (_hasCompatibleReliableTempo(entry, node.proficiencyRule) &&
+                entry.tempoStepNoteValue != null) {
+              values.add(entry.tempoStepNoteValue!);
+            }
+          }
+        }
+      }
+    }
+    return values;
+  }
+}

--- a/lib/presentation/features/practice/practice_page.dart
+++ b/lib/presentation/features/practice/practice_page.dart
@@ -3,6 +3,7 @@ import "package:provider/provider.dart";
 import "package:piano_fitness/presentation/constants/practice_constants.dart";
 import "package:piano_fitness/domain/models/music/chord_progression_type.dart";
 import "package:piano_fitness/domain/models/practice/practice_mode.dart";
+import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
 import "package:piano_fitness/domain/models/practice/exercise_completion_result.dart";
 import "package:piano_fitness/domain/repositories/exercise_history_repository.dart";
 import "package:piano_fitness/domain/repositories/user_profile_repository.dart";
@@ -36,6 +37,8 @@ class PracticePage extends StatelessWidget {
     this.initialMode = PracticeMode.scales,
     this.midiChannel = 0,
     this.initialChordProgression,
+    this.initialConfiguration,
+    this.backTooltip = "Back to Practice Hub",
   });
 
   /// The initial practice mode to display when the page loads.
@@ -46,6 +49,13 @@ class PracticePage extends StatelessWidget {
 
   /// The initial chord progression to pre-select (optional).
   final ChordProgression? initialChordProgression;
+
+  /// An exact exercise configuration supplied by a caller such as the
+  /// technique tree. When present it takes precedence over [initialMode].
+  final ExerciseConfiguration? initialConfiguration;
+
+  /// Accessible label for the source-appropriate back navigation action.
+  final String backTooltip;
 
   @override
   Widget build(BuildContext context) {
@@ -65,6 +75,8 @@ class PracticePage extends StatelessWidget {
       child: _PracticePageView(
         initialMode: initialMode,
         initialChordProgression: initialChordProgression,
+        initialConfiguration: initialConfiguration,
+        backTooltip: backTooltip,
       ),
     );
   }
@@ -74,10 +86,14 @@ class _PracticePageView extends StatefulWidget {
   const _PracticePageView({
     required this.initialMode,
     this.initialChordProgression,
+    this.initialConfiguration,
+    required this.backTooltip,
   });
 
   final PracticeMode initialMode;
   final ChordProgression? initialChordProgression;
+  final ExerciseConfiguration? initialConfiguration;
+  final String backTooltip;
 
   @override
   State<_PracticePageView> createState() => _PracticePageViewState();
@@ -98,6 +114,7 @@ class _PracticePageViewState extends State<_PracticePageView> {
         },
         initialMode: widget.initialMode,
         initialChordProgression: widget.initialChordProgression,
+        initialConfiguration: widget.initialConfiguration,
       );
     });
   }
@@ -185,7 +202,7 @@ class _PracticePageViewState extends State<_PracticePageView> {
         key: const Key("practice_back_button"),
         icon: const Icon(Icons.arrow_back),
         onPressed: () => Navigator.of(context).pop(),
-        tooltip: "Back to Practice Hub",
+        tooltip: widget.backTooltip,
       ),
     );
   }

--- a/lib/presentation/features/practice/practice_page_view_model.dart
+++ b/lib/presentation/features/practice/practice_page_view_model.dart
@@ -109,6 +109,7 @@ class PracticePageViewModel extends ChangeNotifier {
     if (initialConfiguration != null) {
       initialConfiguration.validate();
       _practiceSession!.updateConfiguration(initialConfiguration);
+      notifyListeners();
       return;
     }
 

--- a/lib/presentation/features/practice/practice_page_view_model.dart
+++ b/lib/presentation/features/practice/practice_page_view_model.dart
@@ -90,6 +90,7 @@ class PracticePageViewModel extends ChangeNotifier {
     required void Function(List<int> midiNotes) onHighlightedNotesChanged,
     PracticeMode initialMode = PracticeMode.scales,
     ChordProgression? initialChordProgression,
+    ExerciseConfiguration? initialConfiguration,
   }) {
     _practiceSession = PracticeSession(
       onExerciseCompleted: (result) {
@@ -105,6 +106,12 @@ class PracticePageViewModel extends ChangeNotifier {
         notifyListeners();
       },
     );
+    if (initialConfiguration != null) {
+      initialConfiguration.validate();
+      _practiceSession!.updateConfiguration(initialConfiguration);
+      return;
+    }
+
     var config = _practiceSession!.config.withMode(initialMode);
     if (initialChordProgression != null) {
       config = config.copyWith(

--- a/lib/presentation/features/skill_progression/skill_tree_page.dart
+++ b/lib/presentation/features/skill_progression/skill_tree_page.dart
@@ -50,6 +50,12 @@ class _SkillTreeView extends StatelessWidget {
       for (final proficiency in viewModel.nodeProficiencies)
         proficiency.node.id: proficiency,
     };
+    final groupedNodeIds = viewModel.catalogue.groups
+        .expand((group) => group.nodeIds)
+        .toSet();
+    final ungrouped = viewModel.nodeProficiencies
+        .where((proficiency) => !groupedNodeIds.contains(proficiency.node.id))
+        .toList(growable: false);
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -67,6 +73,12 @@ class _SkillTreeView extends StatelessWidget {
               _SkillNodeCard(proficiency: proficiency),
           const SizedBox(height: 16),
         ],
+        if (ungrouped.isNotEmpty) ...[
+          Text("Other skills", style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 8),
+          for (final proficiency in ungrouped)
+            _SkillNodeCard(proficiency: proficiency),
+        ],
       ],
     );
   }
@@ -80,12 +92,18 @@ class _SkillNodeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final node = proficiency.node;
+    final viewModel = context.read<SkillTreePageViewModel>();
     final prerequisiteNames = node.relations
         .where(
           (relation) =>
               relation.type == SkillRelationType.recommendedPrerequisite,
         )
-        .map((relation) => relation.nodeId.replaceAll("-", " "))
+        .map((relation) {
+          for (final target in viewModel.catalogue.nodes) {
+            if (target.id == relation.nodeId) return target.name;
+          }
+          return relation.description ?? relation.nodeId;
+        })
         .join(", ");
     return Card(
       child: ListTile(
@@ -99,7 +117,10 @@ class _SkillNodeCard extends StatelessWidget {
         trailing: const Icon(Icons.chevron_right),
         onTap: () => Navigator.of(context).push(
           MaterialPageRoute<void>(
-            builder: (_) => SkillNodeDetailPage(proficiency: proficiency),
+            builder: (_) => ChangeNotifierProvider.value(
+              value: viewModel,
+              child: SkillNodeDetailPage(nodeId: node.id),
+            ),
           ),
         ),
       ),
@@ -109,12 +130,19 @@ class _SkillNodeCard extends StatelessWidget {
 
 /// Shows key-level evidence and opens the existing practice workflow.
 class SkillNodeDetailPage extends StatelessWidget {
-  const SkillNodeDetailPage({super.key, required this.proficiency});
+  const SkillNodeDetailPage({super.key, required this.nodeId});
 
-  final SkillNodeProficiency proficiency;
+  final String nodeId;
 
   @override
   Widget build(BuildContext context) {
+    final proficiency = context
+        .select<SkillTreePageViewModel, SkillNodeProficiency?>(
+          (viewModel) => viewModel.proficiencyForNode(nodeId),
+        );
+    if (proficiency == null) {
+      return const Scaffold(body: Center(child: Text("Skill not found.")));
+    }
     return Scaffold(
       appBar: AppBar(title: Text(proficiency.node.name)),
       body: ListView(

--- a/lib/presentation/features/skill_progression/skill_tree_page.dart
+++ b/lib/presentation/features/skill_progression/skill_tree_page.dart
@@ -1,0 +1,219 @@
+import "package:flutter/material.dart";
+import "package:provider/provider.dart";
+import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_proficiency_snapshot.dart";
+import "package:piano_fitness/domain/repositories/exercise_history_repository.dart";
+import "package:piano_fitness/domain/repositories/user_profile_repository.dart";
+import "package:piano_fitness/presentation/features/practice/practice_page.dart";
+import "package:piano_fitness/presentation/features/skill_progression/skill_tree_page_view_model.dart";
+
+/// A positive, freely navigable map of the curated piano technique catalogue.
+class SkillTreePage extends StatelessWidget {
+  const SkillTreePage({super.key, this.catalogue});
+
+  final SkillCatalogue? catalogue;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (context) => SkillTreePageViewModel(
+        userProfileRepository: context.read<IUserProfileRepository>(),
+        exerciseHistoryRepository: context.read<IExerciseHistoryRepository>(),
+        catalogue: catalogue,
+      ),
+      child: const _SkillTreeView(),
+    );
+  }
+}
+
+class _SkillTreeView extends StatelessWidget {
+  const _SkillTreeView();
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.watch<SkillTreePageViewModel>();
+    return Scaffold(
+      appBar: AppBar(title: const Text("Technique Tree")),
+      body: _buildBody(context, viewModel),
+    );
+  }
+
+  Widget _buildBody(BuildContext context, SkillTreePageViewModel viewModel) {
+    if (viewModel.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (viewModel.error != null) {
+      return Center(child: Text(viewModel.error!));
+    }
+    final byId = {
+      for (final proficiency in viewModel.nodeProficiencies)
+        proficiency.node.id: proficiency,
+    };
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text(
+          "Explore exercises and track positive evidence across keys.",
+        ),
+        const SizedBox(height: 16),
+        for (final group in viewModel.catalogue.groups) ...[
+          Text(group.name, style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 4),
+          Text(group.description),
+          const SizedBox(height: 8),
+          for (final nodeId in group.nodeIds)
+            if (byId[nodeId] case final proficiency?)
+              _SkillNodeCard(proficiency: proficiency),
+          const SizedBox(height: 16),
+        ],
+      ],
+    );
+  }
+}
+
+class _SkillNodeCard extends StatelessWidget {
+  const _SkillNodeCard({required this.proficiency});
+
+  final SkillNodeProficiency proficiency;
+
+  @override
+  Widget build(BuildContext context) {
+    final node = proficiency.node;
+    final prerequisiteNames = node.relations
+        .where(
+          (relation) =>
+              relation.type == SkillRelationType.recommendedPrerequisite,
+        )
+        .map((relation) => relation.nodeId.replaceAll("-", " "))
+        .join(", ");
+    return Card(
+      child: ListTile(
+        key: Key("skill_node_${node.id}"),
+        title: Text(node.name),
+        subtitle: Text(
+          "${node.description}\n${proficiency.establishedCheckpointCount} of ${proficiency.checkpointCount} keys established"
+          "${prerequisiteNames.isEmpty ? "" : "\nRecommended first: $prerequisiteNames"}",
+        ),
+        isThreeLine: true,
+        trailing: const Icon(Icons.chevron_right),
+        onTap: () => Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => SkillNodeDetailPage(proficiency: proficiency),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows key-level evidence and opens the existing practice workflow.
+class SkillNodeDetailPage extends StatelessWidget {
+  const SkillNodeDetailPage({super.key, required this.proficiency});
+
+  final SkillNodeProficiency proficiency;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(proficiency.node.name)),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(proficiency.node.description),
+          const SizedBox(height: 8),
+          Text(
+            "${proficiency.establishedCheckpointCount} of ${proficiency.checkpointCount} keys established",
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          for (final checkpoint in proficiency.checkpointProficiencies)
+            _CheckpointCard(
+              checkpoint: checkpoint,
+              rule: proficiency.node.proficiencyRule,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CheckpointCard extends StatelessWidget {
+  const _CheckpointCard({required this.checkpoint, required this.rule});
+
+  final SkillCheckpointProficiency checkpoint;
+  final SkillProficiencyRule rule;
+
+  @override
+  Widget build(BuildContext context) {
+    final tone = checkpoint.hasEstablishedProficiency
+        ? Theme.of(context).colorScheme.primaryContainer
+        : checkpoint.positiveScore > 0
+        ? Theme.of(context).colorScheme.secondaryContainer
+        : Theme.of(context).colorScheme.surfaceContainerHighest;
+    return Semantics(
+      label:
+          "${checkpoint.checkpoint.name}: ${checkpoint.hasEstablishedProficiency ? "established" : "in progress"}",
+      child: Card(
+        color: tone,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                checkpoint.checkpoint.name,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              for (final exercise in checkpoint.exerciseProficiencies) ...[
+                const SizedBox(height: 8),
+                Text(exercise.exercise.name),
+                Text(
+                  "${exercise.progressionQualifyingAttemptCount} of ${rule.evidenceAttemptCount} qualifying attempts"
+                  "${exercise.recentAverageAccuracy == null ? "" : " · ${exercise.recentAverageAccuracy!.toStringAsFixed(0)}% recent accuracy"}",
+                ),
+                Text(_tempoText(exercise)),
+                const SizedBox(height: 4),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton(
+                    key: Key("practice_${exercise.exercise.id}"),
+                    onPressed: () =>
+                        _openPractice(context, exercise.exercise.configuration),
+                    child: const Text("Practice"),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _tempoText(SkillExerciseProficiency exercise) {
+    final bpm = exercise.recentAverageMeasuredBpm;
+    if (bpm != null) {
+      final next = exercise.suggestedNextTempoBpm;
+      return "${bpm.toStringAsFixed(0)} BPM exercise tempo"
+          "${next == null ? "" : " · next ${next.toStringAsFixed(0)} BPM"}";
+    }
+    return rule.tempoEvidencePolicy == TempoEvidencePolicy.notApplicable
+        ? "Tempo not recorded for this exercise"
+        : "Tempo evidence not yet available";
+  }
+
+  void _openPractice(
+    BuildContext context,
+    ExerciseConfiguration configuration,
+  ) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => PracticePage(
+          initialConfiguration: configuration,
+          backTooltip: "Back to Technique Tree",
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/skill_progression/skill_tree_page_view_model.dart
+++ b/lib/presentation/features/skill_progression/skill_tree_page_view_model.dart
@@ -1,0 +1,98 @@
+import "dart:async";
+
+import "package:flutter/foundation.dart";
+import "package:logging/logging.dart";
+import "package:piano_fitness/application/skill_progression/default_skill_catalogue.dart";
+import "package:piano_fitness/domain/models/practice/exercise_history_entry.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_proficiency_snapshot.dart";
+import "package:piano_fitness/domain/repositories/exercise_history_repository.dart";
+import "package:piano_fitness/domain/repositories/user_profile_repository.dart";
+import "package:piano_fitness/domain/services/skill_progression/skill_catalogue_validator.dart";
+import "package:piano_fitness/domain/services/skill_progression/skill_proficiency_evaluator.dart";
+
+/// Reactively derives technique-tree proficiency from the active profile's
+/// existing history stream.
+class SkillTreePageViewModel extends ChangeNotifier {
+  SkillTreePageViewModel({
+    required IUserProfileRepository userProfileRepository,
+    required IExerciseHistoryRepository exerciseHistoryRepository,
+    SkillCatalogue? catalogue,
+  }) : _userProfileRepository = userProfileRepository,
+       _exerciseHistoryRepository = exerciseHistoryRepository,
+       catalogue = catalogue ?? DefaultSkillCatalogue.catalogue {
+    SkillCatalogueValidator.validate(this.catalogue);
+    loadProgress();
+  }
+
+  static final _log = Logger("SkillTreePageViewModel");
+
+  final IUserProfileRepository _userProfileRepository;
+  final IExerciseHistoryRepository _exerciseHistoryRepository;
+  final SkillCatalogue catalogue;
+  StreamSubscription<List<ExerciseHistoryEntry>>? _historySubscription;
+
+  List<SkillNodeProficiency> _nodeProficiencies = const [];
+  bool _isLoading = true;
+  String? _error;
+
+  List<SkillNodeProficiency> get nodeProficiencies =>
+      List.unmodifiable(_nodeProficiencies);
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  /// Begins watching the active profile's history and recomputes on every
+  /// completion, including repetitions made while the tree remains below the
+  /// existing Practice Page route.
+  Future<void> loadProgress() async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final profileId = await _userProfileRepository.getActiveProfileId();
+      if (profileId == null) {
+        _setEntries(const []);
+        return;
+      }
+      await _historySubscription?.cancel();
+      _historySubscription = _exerciseHistoryRepository
+          .watchEntriesForProfile(profileId)
+          .listen(
+            _setEntries,
+            onError: (Object error, StackTrace stackTrace) {
+              _log.severe("Failed to watch skill progress", error, stackTrace);
+              _nodeProficiencies = const [];
+              _error = "Could not load progress. Please try again.";
+              _isLoading = false;
+              notifyListeners();
+            },
+          );
+    } catch (error, stackTrace) {
+      _log.severe(
+        "Failed to load active profile for skill progress",
+        error,
+        stackTrace,
+      );
+      _nodeProficiencies = const [];
+      _error = "Could not load progress. Please try again.";
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void _setEntries(List<ExerciseHistoryEntry> entries) {
+    _nodeProficiencies = catalogue.nodes
+        .map((node) => SkillProficiencyEvaluator.evaluateNode(node, entries))
+        .toList(growable: false);
+    _isLoading = false;
+    _error = null;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _historySubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/presentation/features/skill_progression/skill_tree_page_view_model.dart
+++ b/lib/presentation/features/skill_progression/skill_tree_page_view_model.dart
@@ -35,32 +35,45 @@ class SkillTreePageViewModel extends ChangeNotifier {
   List<SkillNodeProficiency> _nodeProficiencies = const [];
   bool _isLoading = true;
   String? _error;
+  var _isDisposed = false;
 
   List<SkillNodeProficiency> get nodeProficiencies =>
       List.unmodifiable(_nodeProficiencies);
   bool get isLoading => _isLoading;
   String? get error => _error;
 
+  /// Returns the current derived proficiency for a node, if it is catalogued.
+  SkillNodeProficiency? proficiencyForNode(String nodeId) {
+    for (final proficiency in _nodeProficiencies) {
+      if (proficiency.node.id == nodeId) return proficiency;
+    }
+    return null;
+  }
+
   /// Begins watching the active profile's history and recomputes on every
   /// completion, including repetitions made while the tree remains below the
   /// existing Practice Page route.
   Future<void> loadProgress() async {
+    if (_isDisposed) return;
     _isLoading = true;
     _error = null;
     notifyListeners();
 
     try {
       final profileId = await _userProfileRepository.getActiveProfileId();
+      if (_isDisposed) return;
       if (profileId == null) {
         _setEntries(const []);
         return;
       }
       await _historySubscription?.cancel();
+      if (_isDisposed) return;
       _historySubscription = _exerciseHistoryRepository
           .watchEntriesForProfile(profileId)
           .listen(
             _setEntries,
             onError: (Object error, StackTrace stackTrace) {
+              if (_isDisposed) return;
               _log.severe("Failed to watch skill progress", error, stackTrace);
               _nodeProficiencies = const [];
               _error = "Could not load progress. Please try again.";
@@ -69,6 +82,7 @@ class SkillTreePageViewModel extends ChangeNotifier {
             },
           );
     } catch (error, stackTrace) {
+      if (_isDisposed) return;
       _log.severe(
         "Failed to load active profile for skill progress",
         error,
@@ -82,6 +96,7 @@ class SkillTreePageViewModel extends ChangeNotifier {
   }
 
   void _setEntries(List<ExerciseHistoryEntry> entries) {
+    if (_isDisposed) return;
     _nodeProficiencies = catalogue.nodes
         .map((node) => SkillProficiencyEvaluator.evaluateNode(node, entries))
         .toList(growable: false);
@@ -92,6 +107,7 @@ class SkillTreePageViewModel extends ChangeNotifier {
 
   @override
   void dispose() {
+    _isDisposed = true;
     _historySubscription?.cancel();
     super.dispose();
   }

--- a/lib/presentation/widgets/main_navigation.dart
+++ b/lib/presentation/widgets/main_navigation.dart
@@ -7,6 +7,7 @@ import "package:piano_fitness/presentation/features/notifications/notifications_
 import "package:piano_fitness/presentation/features/history/history_page.dart";
 import "package:piano_fitness/presentation/features/play/play_page.dart";
 import "package:piano_fitness/presentation/features/practice/practice_hub_page.dart";
+import "package:piano_fitness/presentation/features/skill_progression/skill_tree_page.dart";
 import "package:piano_fitness/presentation/features/reference/reference_page.dart";
 import "package:piano_fitness/presentation/features/repertoire/repertoire_page.dart";
 import "package:piano_fitness/presentation/features/user_profile/user_profile_page.dart";
@@ -32,6 +33,7 @@ class _MainNavigationState extends State<MainNavigation> {
   static final List<Widget> _pages = <Widget>[
     const PlayPage(),
     const PracticeHubPage(),
+    const SkillTreePage(),
     const ReferencePage(),
     const RepertoirePage(),
     const HistoryPage(),
@@ -41,6 +43,7 @@ class _MainNavigationState extends State<MainNavigation> {
   static const List<String> _pageTitles = [
     "Free Play",
     "Practice",
+    "Technique Tree",
     "Reference",
     "Repertoire",
     "History",
@@ -50,6 +53,7 @@ class _MainNavigationState extends State<MainNavigation> {
   static const List<IconData> _pageIcons = [
     Icons.piano,
     Icons.school,
+    Icons.account_tree_outlined,
     Icons.library_books,
     Icons.library_music,
     Icons.history,
@@ -61,6 +65,7 @@ class _MainNavigationState extends State<MainNavigation> {
   static const List<Key> _tabKeys = [
     Key("nav_tab_free_play"),
     Key("nav_tab_practice"),
+    Key("nav_tab_technique_tree"),
     Key("nav_tab_reference"),
     Key("nav_tab_repertoire"),
     Key("nav_tab_history"),

--- a/test/domain/models/practice/strategies/scales_strategy_test.dart
+++ b/test/domain/models/practice/strategies/scales_strategy_test.dart
@@ -2,11 +2,46 @@ import "package:flutter_test/flutter_test.dart";
 import "package:piano_fitness/domain/models/music/hand_selection.dart";
 import "package:piano_fitness/domain/models/practice/exercise.dart";
 import "package:piano_fitness/domain/models/practice/strategies/scales_strategy.dart";
+import "package:piano_fitness/domain/services/practice/exercise_tempo_calculator.dart";
 import "package:piano_fitness/domain/services/music_theory/scales.dart"
     as music;
 
 void main() {
   group("ScalesStrategy", () {
+    test("defines each scale onset as an eighth note", () {
+      final exercise = ScalesStrategy(
+        key: music.Key.c,
+        scaleType: music.ScaleType.major,
+        handSelection: HandSelection.right,
+        startOctave: 4,
+      ).initializeExercise();
+
+      expect(
+        exercise.steps.map((step) => step.noteValue),
+        everyElement(PracticeStepNoteValue.eighth),
+      );
+    });
+
+    test("converts eighth-note scale onsets to quarter-note BPM", () {
+      final exercise = ScalesStrategy(
+        key: music.Key.c,
+        scaleType: music.ScaleType.major,
+        handSelection: HandSelection.right,
+        startOctave: 4,
+      ).initializeExercise();
+      final onsets = List.generate(
+        exercise.length,
+        (index) => Duration(microseconds: index * 214286),
+      );
+
+      final tempo = ExerciseTempoCalculator.calculate(
+        onsets,
+        noteValue: exercise.uniformTempoNoteValue!,
+      );
+
+      expect(tempo.measuredTempoBpm, closeTo(140, 0.01));
+    });
+
     test("should initialize C major scale sequence for both hands", () {
       final strategy = ScalesStrategy(
         key: music.Key.c,

--- a/test/domain/models/practice/strategies/scales_strategy_test.dart
+++ b/test/domain/models/practice/strategies/scales_strategy_test.dart
@@ -9,17 +9,20 @@ import "package:piano_fitness/domain/services/music_theory/scales.dart"
 void main() {
   group("ScalesStrategy", () {
     test("defines each scale onset as an eighth note", () {
-      final exercise = ScalesStrategy(
-        key: music.Key.c,
-        scaleType: music.ScaleType.major,
-        handSelection: HandSelection.right,
-        startOctave: 4,
-      ).initializeExercise();
+      for (final handSelection in HandSelection.values) {
+        final exercise = ScalesStrategy(
+          key: music.Key.c,
+          scaleType: music.ScaleType.major,
+          handSelection: handSelection,
+          startOctave: 4,
+        ).initializeExercise();
 
-      expect(
-        exercise.steps.map((step) => step.noteValue),
-        everyElement(PracticeStepNoteValue.eighth),
-      );
+        expect(
+          exercise.steps.map((step) => step.noteValue),
+          everyElement(PracticeStepNoteValue.eighth),
+          reason: "${handSelection.name} scale steps should be eighth notes",
+        );
+      }
     });
 
     test("converts eighth-note scale onsets to quarter-note BPM", () {

--- a/test/domain/services/skill_progression/skill_proficiency_evaluator_test.dart
+++ b/test/domain/services/skill_progression/skill_proficiency_evaluator_test.dart
@@ -24,12 +24,23 @@ void main() {
     name: "C major",
     configuration: config,
   );
+  const dConfig = ExerciseConfiguration(
+    practiceMode: PracticeMode.scales,
+    handSelection: HandSelection.both,
+    key: music.Key.d,
+    scaleType: music.ScaleType.major,
+  );
+  const dExercise = SkillExercise(
+    id: "d-major",
+    name: "D major",
+    configuration: dConfig,
+  );
 
   SkillNode node(TempoEvidencePolicy policy) => SkillNode(
     id: "major-scale",
     name: "Major scale",
     description: "",
-    checkpoints: const [],
+    checkpoints: [],
     proficiencyRule: SkillProficiencyRule(
       tempoEvidencePolicy: policy,
       supportedTempoMeasurementVersions:
@@ -44,20 +55,25 @@ void main() {
 
   ExerciseHistoryEntry entry(
     String id, {
+    DateTime? completedAt,
+    ExerciseConfiguration? exerciseConfiguration,
     double accuracy = 95,
     TempoMeasurementQuality? quality,
     int? version,
     double? bpm,
+    PracticeStepNoteValue? tempoStepNoteValue,
   }) => ExerciseHistoryEntry.fromConfiguration(
     id: id,
     profileId: "profile",
-    completedAt: DateTime(2026, 8, int.parse(id.substring(1))),
-    config: config,
+    completedAt: completedAt ?? DateTime(2026, 8),
+    config: exerciseConfiguration ?? config,
     accuracyPercentage: accuracy,
     tempoMeasurementQuality: quality,
     tempoMeasurementVersion: version,
     measuredTempoBpm: bpm,
-    tempoStepNoteValue: bpm == null ? null : PracticeStepNoteValue.quarter,
+    tempoStepNoteValue: bpm == null
+        ? null
+        : tempoStepNoteValue ?? PracticeStepNoteValue.quarter,
   );
 
   group("ExerciseConfigurationIdentity", () {
@@ -74,12 +90,76 @@ void main() {
         ExerciseConfigurationIdentity.fromConfiguration(config),
       );
     });
+
+    test("distinguishes null and empty free-form values", () {
+      final emptyProgression = const ExerciseConfiguration(
+        practiceMode: PracticeMode.chordProgressions,
+        handSelection: HandSelection.both,
+        key: music.Key.c,
+        chordProgressionId: "",
+      );
+      final nullProgression = const ExerciseConfiguration(
+        practiceMode: PracticeMode.scales,
+        handSelection: HandSelection.both,
+        key: music.Key.c,
+        scaleType: music.ScaleType.major,
+      );
+
+      expect(
+        ExerciseConfigurationIdentity.fromConfiguration(emptyProgression),
+        isNot(ExerciseConfigurationIdentity.fromConfiguration(nullProgression)),
+      );
+    });
   });
 
   group("SkillCatalogueValidator", () {
     test("validates the shipped first-slice catalogue", () {
+      SkillCatalogueValidator.validate(DefaultSkillCatalogue.catalogue);
       expect(DefaultSkillCatalogue.catalogue.version, 2);
       expect(DefaultSkillCatalogue.catalogue.nodes, hasLength(7));
+    });
+
+    test("rejects nodes without checkpoints and self-relations", () {
+      final noCheckpoint = SkillCatalogue(
+        id: "test",
+        version: 1,
+        nodes: [
+          SkillNode(
+            id: "node",
+            name: "Node",
+            description: "",
+            proficiencyRule: SkillProficiencyRule(),
+            checkpoints: [],
+          ),
+        ],
+      );
+      final selfRelation = SkillCatalogue(
+        id: "test",
+        version: 1,
+        nodes: [
+          SkillNode(
+            id: "node",
+            name: "Node",
+            description: "",
+            proficiencyRule: SkillProficiencyRule(),
+            checkpoints: [
+              SkillCheckpoint(id: "c", name: "C", exercises: [exercise]),
+            ],
+            relations: const [
+              SkillRelation(type: SkillRelationType.related, nodeId: "node"),
+            ],
+          ),
+        ],
+      );
+
+      expect(
+        () => SkillCatalogueValidator.validate(noCheckpoint),
+        throwsArgumentError,
+      );
+      expect(
+        () => SkillCatalogueValidator.validate(selfRelation),
+        throwsArgumentError,
+      );
     });
 
     test("rejects duplicate exercise configurations", () {
@@ -91,8 +171,8 @@ void main() {
             id: "one",
             name: "One",
             description: "",
-            proficiencyRule: const SkillProficiencyRule(),
-            checkpoints: const [
+            proficiencyRule: SkillProficiencyRule(),
+            checkpoints: [
               SkillCheckpoint(id: "c", name: "C", exercises: [exercise]),
             ],
           ),
@@ -100,8 +180,8 @@ void main() {
             id: "two",
             name: "Two",
             description: "",
-            proficiencyRule: const SkillProficiencyRule(),
-            checkpoints: const [
+            proficiencyRule: SkillProficiencyRule(),
+            checkpoints: [
               SkillCheckpoint(id: "d", name: "D", exercises: [exercise]),
             ],
           ),
@@ -112,6 +192,24 @@ void main() {
         () => SkillCatalogueValidator.validate(catalogue),
         throwsArgumentError,
       );
+    });
+
+    test("does not retain mutable catalogue collections", () {
+      final nodes = <SkillNode>[];
+      final catalogue = SkillCatalogue(id: "test", version: 1, nodes: nodes);
+
+      nodes.add(
+        SkillNode(
+          id: "later",
+          name: "Later",
+          description: "",
+          proficiencyRule: SkillProficiencyRule(),
+          checkpoints: [],
+        ),
+      );
+
+      expect(catalogue.nodes, isEmpty);
+      expect(() => catalogue.nodes.add(nodes.single), throwsUnsupportedError);
     });
   });
 
@@ -249,6 +347,67 @@ void main() {
       expect(proficiency.hasEstablishedProficiency, isTrue);
       expect(proficiency.accuracyQualifyingAttemptCount, 3);
       expect(proficiency.positiveScore, greaterThan(0));
+    });
+
+    test("omits node BPM when qualifying tempo step values differ", () {
+      final proficiencyNode = SkillNode(
+        id: "two-keys",
+        name: "Two keys",
+        description: "",
+        proficiencyRule: SkillProficiencyRule(),
+        checkpoints: [
+          SkillCheckpoint(id: "c", name: "C", exercises: [exercise]),
+          SkillCheckpoint(id: "d", name: "D", exercises: [dExercise]),
+        ],
+      );
+      final history = [
+        entry(
+          "c",
+          quality: TempoMeasurementQuality.reliable,
+          version: TempoMeasurementVersions.current,
+          bpm: 100,
+        ),
+        entry(
+          "d",
+          exerciseConfiguration: dConfig,
+          quality: TempoMeasurementQuality.reliable,
+          version: TempoMeasurementVersions.current,
+          bpm: 100,
+          tempoStepNoteValue: PracticeStepNoteValue.eighth,
+        ),
+      ];
+
+      final proficiency = SkillProficiencyEvaluator.evaluateNode(
+        proficiencyNode,
+        history,
+      );
+
+      expect(proficiency.recentAverageMeasuredBpm, isNull);
+    });
+
+    test("omits node BPM without qualifying tempo evidence", () {
+      final proficiencyNode = SkillNode(
+        id: "one-key",
+        name: "One key",
+        description: "",
+        proficiencyRule: SkillProficiencyRule(),
+        checkpoints: [
+          SkillCheckpoint(id: "c", name: "C", exercises: [exercise]),
+        ],
+      );
+
+      final proficiency =
+          SkillProficiencyEvaluator.evaluateNode(proficiencyNode, [
+            entry(
+              "low-accuracy",
+              accuracy: 20,
+              quality: TempoMeasurementQuality.reliable,
+              version: TempoMeasurementVersions.current,
+              bpm: 100,
+            ),
+          ]);
+
+      expect(proficiency.recentAverageMeasuredBpm, isNull);
     });
   });
 }

--- a/test/domain/services/skill_progression/skill_proficiency_evaluator_test.dart
+++ b/test/domain/services/skill_progression/skill_proficiency_evaluator_test.dart
@@ -1,0 +1,254 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:piano_fitness/application/skill_progression/default_skill_catalogue.dart";
+import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/music/scale_types.dart" as music;
+import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
+import "package:piano_fitness/domain/models/practice/exercise_history_entry.dart";
+import "package:piano_fitness/domain/models/practice/exercise_tempo_result.dart";
+import "package:piano_fitness/domain/models/practice/practice_mode.dart";
+import "package:piano_fitness/domain/models/practice/practice_step_note_value.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+import "package:piano_fitness/domain/services/skill_progression/exercise_configuration_identity.dart";
+import "package:piano_fitness/domain/services/skill_progression/skill_catalogue_validator.dart";
+import "package:piano_fitness/domain/services/skill_progression/skill_proficiency_evaluator.dart";
+
+void main() {
+  const config = ExerciseConfiguration(
+    practiceMode: PracticeMode.scales,
+    handSelection: HandSelection.both,
+    key: music.Key.c,
+    scaleType: music.ScaleType.major,
+  );
+  const exercise = SkillExercise(
+    id: "c-major",
+    name: "C major",
+    configuration: config,
+  );
+
+  SkillNode node(TempoEvidencePolicy policy) => SkillNode(
+    id: "major-scale",
+    name: "Major scale",
+    description: "",
+    checkpoints: const [],
+    proficiencyRule: SkillProficiencyRule(
+      tempoEvidencePolicy: policy,
+      supportedTempoMeasurementVersions:
+          policy == TempoEvidencePolicy.notApplicable
+          ? const {}
+          : const {TempoMeasurementVersions.current},
+      referenceTempoBpm: policy == TempoEvidencePolicy.notApplicable
+          ? null
+          : 100,
+    ),
+  );
+
+  ExerciseHistoryEntry entry(
+    String id, {
+    double accuracy = 95,
+    TempoMeasurementQuality? quality,
+    int? version,
+    double? bpm,
+  }) => ExerciseHistoryEntry.fromConfiguration(
+    id: id,
+    profileId: "profile",
+    completedAt: DateTime(2026, 8, int.parse(id.substring(1))),
+    config: config,
+    accuracyPercentage: accuracy,
+    tempoMeasurementQuality: quality,
+    tempoMeasurementVersion: version,
+    measuredTempoBpm: bpm,
+    tempoStepNoteValue: bpm == null ? null : PracticeStepNoteValue.quarter,
+  );
+
+  group("ExerciseConfigurationIdentity", () {
+    test("normalizes nullable historical defaults", () {
+      final history = ExerciseHistoryEntry.fromConfiguration(
+        id: "e1",
+        profileId: "profile",
+        completedAt: DateTime(2026),
+        config: config,
+      );
+
+      expect(
+        ExerciseConfigurationIdentity.fromHistory(history),
+        ExerciseConfigurationIdentity.fromConfiguration(config),
+      );
+    });
+  });
+
+  group("SkillCatalogueValidator", () {
+    test("validates the shipped first-slice catalogue", () {
+      expect(DefaultSkillCatalogue.catalogue.version, 2);
+      expect(DefaultSkillCatalogue.catalogue.nodes, hasLength(7));
+    });
+
+    test("rejects duplicate exercise configurations", () {
+      final catalogue = SkillCatalogue(
+        id: "test",
+        version: 1,
+        nodes: [
+          SkillNode(
+            id: "one",
+            name: "One",
+            description: "",
+            proficiencyRule: const SkillProficiencyRule(),
+            checkpoints: const [
+              SkillCheckpoint(id: "c", name: "C", exercises: [exercise]),
+            ],
+          ),
+          SkillNode(
+            id: "two",
+            name: "Two",
+            description: "",
+            proficiencyRule: const SkillProficiencyRule(),
+            checkpoints: const [
+              SkillCheckpoint(id: "d", name: "D", exercises: [exercise]),
+            ],
+          ),
+        ],
+      );
+
+      expect(
+        () => SkillCatalogueValidator.validate(catalogue),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group("SkillProficiencyEvaluator", () {
+    test("required policy establishes only from reliable compatible tempo", () {
+      final history = [
+        entry(
+          "e1",
+          quality: TempoMeasurementQuality.reliable,
+          version: TempoMeasurementVersions.current,
+          bpm: 80,
+        ),
+        entry(
+          "e2",
+          quality: TempoMeasurementQuality.reliable,
+          version: TempoMeasurementVersions.current,
+          bpm: 90,
+        ),
+        entry(
+          "e3",
+          quality: TempoMeasurementQuality.reliable,
+          version: TempoMeasurementVersions.current,
+          bpm: 100,
+        ),
+        entry(
+          "e4",
+          quality: TempoMeasurementQuality.inconsistent,
+          version: TempoMeasurementVersions.current,
+        ),
+      ];
+
+      final proficiency = SkillProficiencyEvaluator.evaluateExercise(
+        node(TempoEvidencePolicy.required),
+        exercise,
+        history,
+      );
+
+      expect(proficiency.hasEstablishedProficiency, isTrue);
+      expect(proficiency.reliableTempoAttemptCount, 3);
+      expect(proficiency.recentAverageMeasuredBpm, 90);
+      expect(proficiency.historicalBestMeasuredBpm, 100);
+    });
+
+    test("required policy ignores incompatible tempo versions", () {
+      final history = List.generate(
+        3,
+        (index) => entry(
+          "e${index + 1}",
+          quality: TempoMeasurementQuality.reliable,
+          version: 1,
+          bpm: 80,
+        ),
+      );
+
+      final proficiency = SkillProficiencyEvaluator.evaluateExercise(
+        node(TempoEvidencePolicy.required),
+        exercise,
+        history,
+      );
+
+      expect(proficiency.hasSufficientAccuracyEvidence, isTrue);
+      expect(proficiency.hasEstablishedProficiency, isFalse);
+      expect(proficiency.recentAverageMeasuredBpm, isNull);
+    });
+
+    test("does not mix pre-correction scale tempo with version 3 scales", () {
+      final scaleNode = DefaultSkillCatalogue.catalogue.nodes.firstWhere(
+        (node) => node.id == "major-scale",
+      );
+      final scaleExercise = scaleNode.checkpoints.first.exercises.first;
+      final history = List.generate(
+        3,
+        (index) => entry(
+          "e${index + 1}",
+          quality: TempoMeasurementQuality.reliable,
+          version: TempoMeasurementVersions.declaredStepDurations,
+          bpm: 280,
+        ),
+      );
+
+      final proficiency = SkillProficiencyEvaluator.evaluateExercise(
+        scaleNode,
+        scaleExercise,
+        history,
+      );
+
+      expect(proficiency.hasSufficientAccuracyEvidence, isTrue);
+      expect(proficiency.reliableTempoAttemptCount, 0);
+      expect(proficiency.hasEstablishedProficiency, isFalse);
+    });
+
+    test(
+      "optional policy establishes from accurate attempts without tempo",
+      () {
+        final proficiency = SkillProficiencyEvaluator.evaluateExercise(
+          node(TempoEvidencePolicy.optional),
+          exercise,
+          [entry("e1"), entry("e2"), entry("e3")],
+        );
+
+        expect(proficiency.hasEstablishedProficiency, isTrue);
+        expect(proficiency.reliableTempoAttemptCount, 0);
+        expect(proficiency.recentAverageMeasuredBpm, isNull);
+      },
+    );
+
+    test("not-applicable policy does not use tempo evidence", () {
+      final proficiency = SkillProficiencyEvaluator.evaluateExercise(
+        node(TempoEvidencePolicy.notApplicable),
+        exercise,
+        [
+          entry(
+            "e1",
+            quality: TempoMeasurementQuality.reliable,
+            version: TempoMeasurementVersions.current,
+            bpm: 80,
+          ),
+          entry("e2"),
+          entry("e3"),
+        ],
+      );
+
+      expect(proficiency.hasEstablishedProficiency, isTrue);
+      expect(proficiency.progressionQualifyingAttemptCount, 3);
+      expect(proficiency.recentAverageMeasuredBpm, isNull);
+    });
+
+    test("below-threshold attempts never reduce positive evidence", () {
+      final proficiency = SkillProficiencyEvaluator.evaluateExercise(
+        node(TempoEvidencePolicy.optional),
+        exercise,
+        [entry("e1"), entry("e2"), entry("e3"), entry("e4", accuracy: 50)],
+      );
+
+      expect(proficiency.hasEstablishedProficiency, isTrue);
+      expect(proficiency.accuracyQualifyingAttemptCount, 3);
+      expect(proficiency.positiveScore, greaterThan(0));
+    });
+  });
+}

--- a/test/presentation/features/practice/practice_page_test.dart
+++ b/test/presentation/features/practice/practice_page_test.dart
@@ -1,5 +1,12 @@
+import "package:flutter/widgets.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:provider/provider.dart";
+import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/music/scale_types.dart" as music;
+import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
+import "package:piano_fitness/domain/models/practice/practice_mode.dart";
 import "package:piano_fitness/presentation/features/practice/practice_page.dart";
+import "package:piano_fitness/presentation/features/practice/practice_page_view_model.dart";
 import "../../../shared/test_helpers/widget_test_helper.dart";
 import "../../../shared/midi_mocks.dart";
 
@@ -13,6 +20,41 @@ void main() {
       await tester.pump();
 
       expect(find.byType(PracticePage), findsOneWidget);
+    });
+
+    testWidgets("forwards initial configuration and back tooltip", (
+      tester,
+    ) async {
+      const configuration = ExerciseConfiguration(
+        practiceMode: PracticeMode.dominantCadence,
+        handSelection: HandSelection.right,
+        key: music.Key.d,
+      );
+
+      await tester.pumpWidget(
+        createTestWidget(
+          const PracticePage(
+            initialConfiguration: configuration,
+            backTooltip: "Back to Technique Tree",
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final scaffoldContext = tester.element(
+        find.byKey(const ValueKey("practice_page_scaffold")),
+      );
+      final viewModel = scaffoldContext.read<PracticePageViewModel>();
+      expect(
+        viewModel.currentConfiguration!.practiceMode,
+        PracticeMode.dominantCadence,
+      );
+      expect(
+        viewModel.currentConfiguration!.handSelection,
+        HandSelection.right,
+      );
+      expect(viewModel.currentConfiguration!.key, music.Key.d);
+      expect(find.byTooltip("Back to Technique Tree"), findsOneWidget);
     });
   });
 }

--- a/test/presentation/features/practice/practice_page_view_model_test.dart
+++ b/test/presentation/features/practice/practice_page_view_model_test.dart
@@ -125,6 +125,9 @@ void main() {
         key: music.Key.d,
       );
 
+      var listenerCalls = 0;
+      viewModel.addListener(() => listenerCalls++);
+
       viewModel.initializePracticeSession(
         onExerciseCompleted: (_) {},
         onHighlightedNotesChanged: (_) {},
@@ -141,6 +144,7 @@ void main() {
         HandSelection.right,
       );
       expect(viewModel.currentConfiguration!.key, music.Key.d);
+      expect(listenerCalls, greaterThan(0));
     });
 
     test("should handle MIDI data and update state for note on events", () {

--- a/test/presentation/features/practice/practice_page_view_model_test.dart
+++ b/test/presentation/features/practice/practice_page_view_model_test.dart
@@ -118,6 +118,31 @@ void main() {
       expect(viewModel.practiceSession!.practiceActive, isFalse);
     });
 
+    test("uses an exact initial configuration over the initial mode", () {
+      const configuration = ExerciseConfiguration(
+        practiceMode: PracticeMode.dominantCadence,
+        handSelection: HandSelection.right,
+        key: music.Key.d,
+      );
+
+      viewModel.initializePracticeSession(
+        onExerciseCompleted: (_) {},
+        onHighlightedNotesChanged: (_) {},
+        initialMode: PracticeMode.chordsByKey,
+        initialConfiguration: configuration,
+      );
+
+      expect(
+        viewModel.currentConfiguration!.practiceMode,
+        PracticeMode.dominantCadence,
+      );
+      expect(
+        viewModel.currentConfiguration!.handSelection,
+        HandSelection.right,
+      );
+      expect(viewModel.currentConfiguration!.key, music.Key.d);
+    });
+
     test("should handle MIDI data and update state for note on events", () {
       final midiData = Uint8List.fromList([0x90, 60, 100]);
 
@@ -845,7 +870,7 @@ void main() {
             entry.tempoMeasurementVersion,
             TempoMeasurementVersions.current,
           );
-          expect(entry.tempoStepNoteValue, PracticeStepNoteValue.quarter);
+          expect(entry.tempoStepNoteValue, PracticeStepNoteValue.eighth);
         },
       );
 

--- a/test/presentation/features/skill_progression/skill_tree_page_view_model_test.dart
+++ b/test/presentation/features/skill_progression/skill_tree_page_view_model_test.dart
@@ -27,10 +27,10 @@ void main() {
         id: "major-scale",
         name: "Major scale",
         description: "",
-        proficiencyRule: const SkillProficiencyRule(
+        proficiencyRule: SkillProficiencyRule(
           tempoEvidencePolicy: TempoEvidencePolicy.optional,
         ),
-        checkpoints: const [
+        checkpoints: [
           SkillCheckpoint(
             id: "c",
             name: "C",
@@ -82,4 +82,26 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     expect(viewModel.nodeProficiencies.single.establishedCheckpointCount, 1);
   });
+
+  test(
+    "does not subscribe after being disposed during profile lookup",
+    () async {
+      final profiles = MockIUserProfileRepository();
+      final history = MockIExerciseHistoryRepository();
+      final profileId = Completer<String?>();
+      when(profiles.getActiveProfileId()).thenAnswer((_) => profileId.future);
+
+      final viewModel = SkillTreePageViewModel(
+        userProfileRepository: profiles,
+        exerciseHistoryRepository: history,
+        catalogue: catalogue,
+      );
+      viewModel.dispose();
+
+      profileId.complete("profile");
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(history.watchEntriesForProfile(any));
+    },
+  );
 }

--- a/test/presentation/features/skill_progression/skill_tree_page_view_model_test.dart
+++ b/test/presentation/features/skill_progression/skill_tree_page_view_model_test.dart
@@ -1,0 +1,85 @@
+import "dart:async";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:mockito/mockito.dart";
+import "package:piano_fitness/domain/models/music/hand_selection.dart";
+import "package:piano_fitness/domain/models/music/scale_types.dart" as music;
+import "package:piano_fitness/domain/models/practice/exercise_configuration.dart";
+import "package:piano_fitness/domain/models/practice/exercise_history_entry.dart";
+import "package:piano_fitness/domain/models/practice/practice_mode.dart";
+import "package:piano_fitness/domain/models/skill_progression/skill_catalogue.dart";
+import "package:piano_fitness/presentation/features/skill_progression/skill_tree_page_view_model.dart";
+
+import "../../../shared/test_helpers/mock_repositories.mocks.dart";
+
+void main() {
+  const config = ExerciseConfiguration(
+    practiceMode: PracticeMode.scales,
+    handSelection: HandSelection.both,
+    key: music.Key.c,
+    scaleType: music.ScaleType.major,
+  );
+  final catalogue = SkillCatalogue(
+    id: "test",
+    version: 1,
+    nodes: [
+      SkillNode(
+        id: "major-scale",
+        name: "Major scale",
+        description: "",
+        proficiencyRule: const SkillProficiencyRule(
+          tempoEvidencePolicy: TempoEvidencePolicy.optional,
+        ),
+        checkpoints: const [
+          SkillCheckpoint(
+            id: "c",
+            name: "C",
+            exercises: [
+              SkillExercise(
+                id: "c-major",
+                name: "C major",
+                configuration: config,
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+
+  ExerciseHistoryEntry entry(String id) =>
+      ExerciseHistoryEntry.fromConfiguration(
+        id: id,
+        profileId: "profile",
+        completedAt: DateTime(2026, 8, int.parse(id.substring(1))),
+        config: config,
+        accuracyPercentage: 95,
+      );
+
+  test("recalculates coverage for reactive history updates", () async {
+    final profiles = MockIUserProfileRepository();
+    final history = MockIExerciseHistoryRepository();
+    final controller = StreamController<List<ExerciseHistoryEntry>>();
+    addTearDown(controller.close);
+    when(profiles.getActiveProfileId()).thenAnswer((_) async => "profile");
+    when(
+      history.watchEntriesForProfile("profile"),
+    ).thenAnswer((_) => controller.stream);
+
+    final viewModel = SkillTreePageViewModel(
+      userProfileRepository: profiles,
+      exerciseHistoryRepository: history,
+      catalogue: catalogue,
+    );
+    addTearDown(viewModel.dispose);
+    await Future<void>.delayed(Duration.zero);
+
+    controller.add([entry("e1"), entry("e2")]);
+    await Future<void>.delayed(Duration.zero);
+    expect(viewModel.nodeProficiencies.single.establishedCheckpointCount, 0);
+
+    controller.add([entry("e1"), entry("e2"), entry("e3")]);
+    await Future<void>.delayed(Duration.zero);
+    expect(viewModel.nodeProficiencies.single.establishedCheckpointCount, 1);
+  });
+}

--- a/test/presentation/widgets/main_navigation_test.dart
+++ b/test/presentation/widgets/main_navigation_test.dart
@@ -28,6 +28,7 @@ Future<void> navigateToTab(WidgetTester tester, Key tabKey) async {
 const List<String> _pageTitlesForTest = [
   "Free Play",
   "Practice",
+  "Technique Tree",
   "Reference",
   "Repertoire",
   "History",
@@ -72,6 +73,7 @@ void main() {
       // Verify bottom navigation bar and its items using stable key
       expect(find.byKey(const Key("bottom_navigation_bar")), findsOneWidget);
       expect(find.text("Practice"), findsWidgets);
+      expect(find.text("Technique Tree"), findsWidgets);
       expect(find.text("Reference"), findsWidgets);
       expect(find.text("Repertoire"), findsWidgets);
     });
@@ -89,11 +91,18 @@ void main() {
       expect(find.text("Practice"), findsWidgets);
       expect(find.byIcon(Icons.school), findsWidgets);
 
+      // Navigate to Technique Tree using stable key
+      await navigateToTab(tester, const Key("nav_tab_technique_tree"));
+
+      expectTabActive(tester, 2);
+      expect(find.text("Technique Tree"), findsWidgets);
+      expect(find.byIcon(Icons.account_tree_outlined), findsWidgets);
+
       // Navigate to Reference tab using stable key
       await navigateToTab(tester, const Key("nav_tab_reference"));
 
       // Verify page switched to Reference
-      expectTabActive(tester, 2);
+      expectTabActive(tester, 3);
       expect(find.text("Reference"), findsWidgets);
       expect(find.byIcon(Icons.library_books), findsWidgets);
 
@@ -101,7 +110,7 @@ void main() {
       await navigateToTab(tester, const Key("nav_tab_repertoire"));
 
       // Verify page switched to Repertoire
-      expectTabActive(tester, 3);
+      expectTabActive(tester, 4);
       expect(find.text("Repertoire"), findsWidgets);
       expect(find.byIcon(Icons.library_music), findsWidgets);
 
@@ -182,6 +191,7 @@ void main() {
 
           final tabKeys = [
             const Key("nav_tab_practice"),
+            const Key("nav_tab_technique_tree"),
             const Key("nav_tab_reference"),
             const Key("nav_tab_repertoire"),
           ];
@@ -329,7 +339,7 @@ void main() {
         await navigateToTab(tester, const Key("nav_tab_reference"));
 
         // Verify state updated
-        expectTabActive(tester, 2);
+        expectTabActive(tester, 3);
       });
 
       testWidgets("should use IndexedStack to preserve page state", (
@@ -352,14 +362,14 @@ void main() {
           find.byType(IndexedStack),
         );
         expect(indexedStack.index, equals(0));
-        expect(indexedStack.children.length, equals(5));
+        expect(indexedStack.children.length, equals(6));
 
         // Navigate to History tab and verify IndexedStack index updates
         await navigateToTab(tester, const Key("nav_tab_history"));
         final historyStack = tester.widget<IndexedStack>(
           find.byType(IndexedStack),
         );
-        expect(historyStack.index, equals(4));
+        expect(historyStack.index, equals(5));
       });
     });
 


### PR DESCRIPTION
## Summary
- add a validated skill catalogue, history matching, and positive proficiency evaluation
- add the reactive Technique Tree as a top-level navigation destination
- launch exact catalogue configurations through the existing Practice Page
- correct scale tempo to use eighth-note onsets and isolate it in tempo measurement version 3

## Validation
- focused progress, scale-tempo, Practice Page, and navigation tests
- flutter analyze
- ./scripts/check-layer-boundaries.sh

## Note
The full suite still has two pre-existing date-sensitive notification scheduling assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Technique Tree for exploring skills, prerequisites, checkpoints, and exercise progress.
  - View detailed proficiency evidence, accuracy, tempo information, and recommended practice actions.
  - Launch practice sessions directly from selected skill exercises.
  - Added a foundational progression catalogue covering scales, arpeggios, chords, progressions, and cadences.
  - Added support for opening practice with a specific exercise configuration.

- **Improvements**
  - Scale exercises now explicitly use eighth-note practice steps for more accurate tempo tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->